### PR TITLE
Rename Renderer\Backend\Bitmap -> \Png.

### DIFF
--- a/autoload_classmap.php
+++ b/autoload_classmap.php
@@ -10,7 +10,7 @@ return array(
     'BaconQrCode\Renderer\Backend\Eps'                  => __DIR__ . '/src/BaconQrCode/Renderer/Backend/Eps.php',
     'BaconQrCode\Renderer\Backend\BackendInterface'     => __DIR__ . '/src/BaconQrCode/Renderer/Backend/BackendInterface.php',
     'BaconQrCode\Renderer\Backend\Svg'                  => __DIR__ . '/src/BaconQrCode/Renderer/Backend/Svg.php',
-    'BaconQrCode\Renderer\Backend\Bitmap'               => __DIR__ . '/src/BaconQrCode/Renderer/Backend/Bitmap.php',
+    'BaconQrCode\Renderer\Backend\Png'                  => __DIR__ . '/src/BaconQrCode/Renderer/Backend/Png.php',
     'BaconQrCode\Renderer\RendererInterface'            => __DIR__ . '/src/BaconQrCode/Renderer/RendererInterface.php',
     'BaconQrCode\Renderer\Decorator\FinderPattern'      => __DIR__ . '/src/BaconQrCode/Renderer/Decorator/FinderPattern.php',
     'BaconQrCode\Renderer\Decorator\DecoratorInterface' => __DIR__ . '/src/BaconQrCode/Renderer/Decorator/DecoratorInterface.php',

--- a/src/BaconQrCode/Renderer/Backend/Png.php
+++ b/src/BaconQrCode/Renderer/Backend/Png.php
@@ -13,9 +13,9 @@ use BaconQrCode\Exception;
 use BaconQrCode\Renderer\Color\ColorInterface;
 
 /**
- * Bitmap backend.
+ * Png backend.
  */
-class Bitmap implements BackendInterface
+class Png implements BackendInterface
 {
     /**
      * Image resource used when drawing.


### PR DESCRIPTION
Because Backend\Svg and Backend\Eps are also names of formats, while "Bitmap" class was rendering specifically PNG bytestream.
