### PR TITLE
Changing the Interface in Module.php so it works on Zend 2.2

### DIFF
--- a/Module.php
+++ b/Module.php
@@ -25,7 +25,7 @@ class Module implements AutoloaderProviderInterface
     {
         return array(
             'Zend\Loader\ClassMapAutoloader' => array(
-                __DIR__ . '/../../autoload_classmap.php',
+                __DIR__ . '/autoload_classmap.php',
             ),
             'Zend\Loader\StandardAutoloader' => array(
                 'namespaces' => array(


### PR DESCRIPTION
I was having a problem with Zend Framework 2.2, because it wouldn't load the module. Then, I moved `Module.php` to where it works and changed the Interface it uses because I guess that one that was there was for ZF2 Beta.
