### PR TITLE
Correct HHVM Issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,7 @@ php:
   - 5.3
   - 5.4
   - 5.5
+  - 7.0
+  - hhvm
 
 script: phpunit --bootstrap tests/bootstrap.php --configuration tests/phpunit.xml tests

--- a/src/BaconQrCode/Common/BitMatrix.php
+++ b/src/BaconQrCode/Common/BitMatrix.php
@@ -257,7 +257,7 @@ class BitMatrix
             return null;
         }
 
-        return SplFixedArray::fromArray(array($left, $top, $width, $height));
+        return SplFixedArray::fromArray(array($left, $top, $width, $height), false);
     }
 
     /**
@@ -291,7 +291,7 @@ class BitMatrix
 
         $x += $bit;
 
-        return SplFixedArray::fromArray(array($x, $y));
+        return SplFixedArray::fromArray(array($x, $y), false);
     }
 
     /**
@@ -325,7 +325,7 @@ class BitMatrix
 
         $x += $bit;
 
-        return SplFixedArray::fromArray(array($x, $y));
+        return SplFixedArray::fromArray(array($x, $y), false);
     }
 
     /**

--- a/src/BaconQrCode/Common/ReedSolomonCodec.php
+++ b/src/BaconQrCode/Common/ReedSolomonCodec.php
@@ -122,8 +122,8 @@ class ReedSolomonCodec
         $this->symbolSize = $symbolSize;
         $this->blockSize  = (1 << $symbolSize) - 1;
         $this->padding    = $padding;
-        $this->alphaTo    = SplFixedArray::fromArray(array_fill(0, $this->blockSize + 1, 0));
-        $this->indexOf    = SplFixedArray::fromArray(array_fill(0, $this->blockSize + 1, 0));
+        $this->alphaTo    = SplFixedArray::fromArray(array_fill(0, $this->blockSize + 1, 0), false);
+        $this->indexOf    = SplFixedArray::fromArray(array_fill(0, $this->blockSize + 1, 0), false);
 
         // Generate galous field lookup table
         $this->indexOf[0]                = $this->blockSize;
@@ -149,7 +149,7 @@ class ReedSolomonCodec
         }
 
         // Form RS code generator polynomial from its roots
-        $this->generatorPoly = SplFixedArray::fromArray(array_fill(0, $numRoots + 1, 0));
+        $this->generatorPoly = SplFixedArray::fromArray(array_fill(0, $numRoots + 1, 0), false);
         $this->firstRoot     = $firstRoot;
         $this->primitive     = $primitive;
         $this->numRoots      = $numRoots;
@@ -229,8 +229,8 @@ class ReedSolomonCodec
     public function decode(SplFixedArray $data, SplFixedArray $erasures = null)
     {
         // This speeds up the initialization a bit.
-        $numRootsPlusOne = SplFixedArray::fromArray(array_fill(0, $this->numRoots + 1, 0));
-        $numRoots        = SplFixedArray::fromArray(array_fill(0, $this->numRoots, 0));
+        $numRootsPlusOne = SplFixedArray::fromArray(array_fill(0, $this->numRoots + 1, 0), false);
+        $numRoots        = SplFixedArray::fromArray(array_fill(0, $this->numRoots, 0), false);
 
         $lambda    = clone $numRootsPlusOne;
         $b         = clone $numRootsPlusOne;
@@ -242,7 +242,7 @@ class ReedSolomonCodec
         $numErasures = ($erasures !== null ? count($erasures) : 0);
 
         // Form the Syndromes; i.e., evaluate data(x) at roots of g(x)
-        $syndromes = SplFixedArray::fromArray(array_fill(0, $this->numRoots, $data[0]));
+        $syndromes = SplFixedArray::fromArray(array_fill(0, $this->numRoots, $data[0]), false);
 
         for ($i = 1; $i < $this->blockSize - $this->padding; $i++) {
             for ($j = 0; $j < $this->numRoots; $j++) {
@@ -314,7 +314,7 @@ class ReedSolomonCodec
                 $tmp = $b->toArray();
                 array_unshift($tmp, $this->blockSize);
                 array_pop($tmp);
-                $b = SplFixedArray::fromArray($tmp);
+                $b = SplFixedArray::fromArray($tmp, false);
             } else {
                 $t[0] = $lambda[0];
 
@@ -340,7 +340,7 @@ class ReedSolomonCodec
                     $tmp = $b->toArray();
                     array_unshift($tmp, $this->blockSize);
                     array_pop($tmp);
-                    $b = SplFixedArray::fromArray($tmp);
+                    $b = SplFixedArray::fromArray($tmp, false);
                 }
 
                 $lambda = clone $t;

--- a/src/BaconQrCode/Common/Version.php
+++ b/src/BaconQrCode/Common/Version.php
@@ -680,8 +680,8 @@ class Version
 
         self::$versions[$versionNumber - 1] = new self(
             $versionNumber,
-            SplFixedArray::fromArray($patterns),
-            SplFixedArray::fromArray($ecBlocks)
+            SplFixedArray::fromArray($patterns, false),
+            SplFixedArray::fromArray($ecBlocks, false)
         );
     }
 }

--- a/src/BaconQrCode/Common/Version.php
+++ b/src/BaconQrCode/Common/Version.php
@@ -278,7 +278,7 @@ class Version
     {
         switch ($versionNumber) {
             case 1:
-                $patterns = array(6, 12);
+                $patterns = array();
                 $ecBlocks = array(
                     new EcBlocks(7, new EcBlock(1, 19)),
                     new EcBlocks(10, new EcBlock(1, 16)),

--- a/src/BaconQrCode/Common/Version.php
+++ b/src/BaconQrCode/Common/Version.php
@@ -278,7 +278,7 @@ class Version
     {
         switch ($versionNumber) {
             case 1:
-                $patterns = array();
+                $patterns = array(6, 12);
                 $ecBlocks = array(
                     new EcBlocks(7, new EcBlock(1, 19)),
                     new EcBlocks(10, new EcBlock(1, 16)),

--- a/tests/BaconQrCode/Common/ReedSolomonCodecTest.php
+++ b/tests/BaconQrCode/Common/ReedSolomonCodecTest.php
@@ -46,7 +46,7 @@ class ReedSolomonTest extends TestCase
 
         for ($errors = 0; $errors <= $numRoots / 2; $errors++) {
             // Load block with random data and encode
-            $block = SplFixedArray::fromArray(array_fill(0, $blockSize, 0));
+            $block = SplFixedArray::fromArray(array_fill(0, $blockSize, 0), false);
 
             for ($i = 0; $i < $dataSize; $i++) {
                 $block[$i] = mt_rand(0, $blockSize);
@@ -54,8 +54,8 @@ class ReedSolomonTest extends TestCase
 
             // Make temporary copy
             $tBlock         = clone $block;
-            $parity         = SplFixedArray::fromArray(array_fill(0, $numRoots, 0));
-            $errorLocations = SplFixedArray::fromArray(array_fill(0, $blockSize, 0));
+            $parity         = SplFixedArray::fromArray(array_fill(0, $numRoots, 0), false);
+            $errorLocations = SplFixedArray::fromArray(array_fill(0, $blockSize, 0), false);
             $erasures       = array();
 
             // Create parity
@@ -84,7 +84,7 @@ class ReedSolomonTest extends TestCase
                 $tBlock[$errorLocation] ^= $errorValue;
             }
 
-            $erasures = SplFixedArray::fromArray($erasures);
+            $erasures = SplFixedArray::fromArray($erasures, false);
 
             // Decode the errored block
             $foundErrors = $codec->decode($tBlock, $erasures);

--- a/tests/BaconQrCode/Encoder/EncoderTest.php
+++ b/tests/BaconQrCode/Encoder/EncoderTest.php
@@ -348,7 +348,7 @@ class EncoderTest extends TestCase
 
     public function testInterleaveWithEcBytes()
     {
-        $dataBytes = SplFixedArray::fromArray(array(32, 65, 205, 69, 41, 220, 46, 128, 236));
+        $dataBytes = SplFixedArray::fromArray(array(32, 65, 205, 69, 41, 220, 46, 128, 236), false);
         $in        = new BitArray();
 
         foreach ($dataBytes as $dataByte) {
@@ -361,7 +361,7 @@ class EncoderTest extends TestCase
             32, 65, 205, 69, 41, 220, 46, 128, 236,
             // Error correction bytes.
             42, 159, 74, 221, 244, 169, 239, 150, 138, 70, 237, 85, 224, 96, 74, 219, 61,
-        ));
+        ), false);
 
         $out = $outBits->toBytes(0, count($expected));
 
@@ -449,20 +449,20 @@ class EncoderTest extends TestCase
     {
         // Numbers are from http://www.swetake.com/qr/qr3.html and
         // http://www.swetake.com/qr/qr9.html
-        $dataBytes = SplFixedArray::fromArray(array(32, 65, 205, 69, 41, 220, 46, 128, 236));
+        $dataBytes = SplFixedArray::fromArray(array(32, 65, 205, 69, 41, 220, 46, 128, 236), false);
         $ecBytes   = $this->methods['generateEcBytes']->invoke(null, $dataBytes, 17);
-        $expected  = SplFixedArray::fromArray(array(42, 159, 74, 221, 244, 169, 239, 150, 138, 70, 237, 85, 224, 96, 74, 219, 61));
+        $expected  = SplFixedArray::fromArray(array(42, 159, 74, 221, 244, 169, 239, 150, 138, 70, 237, 85, 224, 96, 74, 219, 61), false);
         $this->assertEquals($expected, $ecBytes);
 
-        $dataBytes = SplFixedArray::fromArray(array(67, 70, 22, 38, 54, 70, 86, 102, 118, 134, 150, 166, 182, 198, 214));
+        $dataBytes = SplFixedArray::fromArray(array(67, 70, 22, 38, 54, 70, 86, 102, 118, 134, 150, 166, 182, 198, 214), false);
         $ecBytes   = $this->methods['generateEcBytes']->invoke(null, $dataBytes, 18);
-        $expected  = SplFixedArray::fromArray(array(175, 80, 155, 64, 178, 45, 214, 233, 65, 209, 12, 155, 117, 31, 140, 214, 27, 187));
+        $expected  = SplFixedArray::fromArray(array(175, 80, 155, 64, 178, 45, 214, 233, 65, 209, 12, 155, 117, 31, 140, 214, 27, 187), false);
         $this->assertEquals($expected, $ecBytes);
 
         // High-order zero coefficient case.
-        $dataBytes = SplFixedArray::fromArray(array(32, 49, 205, 69, 42, 20, 0, 236, 17));
+        $dataBytes = SplFixedArray::fromArray(array(32, 49, 205, 69, 42, 20, 0, 236, 17), false);
         $ecBytes   = $this->methods['generateEcBytes']->invoke(null, $dataBytes, 17);
-        $expected  = SplFixedArray::fromArray(array(0, 3, 130, 179, 194, 0, 55, 211, 110, 79, 98, 72, 170, 96, 211, 137, 213));
+        $expected  = SplFixedArray::fromArray(array(0, 3, 130, 179, 194, 0, 55, 211, 110, 79, 98, 72, 170, 96, 211, 137, 213), false);
         $this->assertEquals($expected, $ecBytes);
     }
 }


### PR DESCRIPTION
Fixes an HHVM bug that results with the following exception:  max(): Array must contain at least one element.

Please merge and release a 1.0.1.  We use this heavily as a dependency.  Thank you!