### PR TITLE
Add ext-iconv as requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,8 @@
     "license" : "BSD-2-Clause",
     "homepage": "https://github.com/Bacon/BaconQrCode",
     "require": {
-        "php": ">=5.3.3"
+        "php": ">=5.3.3",
+        "ext-iconv": "*"
     },
     "suggest": {
         "ext-gd": "to generate QR code images"


### PR DESCRIPTION
Users with a `--disable-all` build notice it during install then instead of during runtime.