### PR TITLE
Add `compact` option on Text renderer

### DIFF
--- a/src/BaconQrCode/Renderer/Text/Plain.php
+++ b/src/BaconQrCode/Renderer/Text/Plain.php
@@ -209,25 +209,28 @@ class Plain implements RendererInterface
         $width  = $matrix->getWidth();
         $margin = str_repeat($this->emptyBlock, $this->margin);
 
-        // Top margin
-        for ($x = 0; $x < $this->margin; $x++) {
-            $result .= str_repeat($this->emptyBlock, $width + 2 * $this->margin)."\n";
-        }
-
         // Body
         $array = $matrix->getArray();
 
         if ($this->compact) {
-            $len = $array->getSize();
-            $size = $array[0]->getSize();
+            // Convert SplFixedArray to native array.
+            $array = $array->toArray();
+            $size = sizeof($array[0]);
+            $emptyRow = array_fill(0, $size, 0);
+
+            if ($this->margin > 0) {
+                for ($i = 0; $i < $this->margin; $i++) {
+                    array_unshift($array, $emptyRow);
+                    $array[] = $emptyRow;
+                }
+            }
+
+            $len = sizeof($array);
 
             // If not an even rows, fill an empty blocks row
             if ($len % 2 !== 0) {
-                $array->setSize($len + 1);
-                for ($i = 0; $i < $size; $i++) {
-                    $array[$len][$i] = 0;
-                }
                 $len++;
+                $array[] = $emptyRow;
             }
 
             for ($i = 0; $i < $len; $i++) {
@@ -250,6 +253,10 @@ class Plain implements RendererInterface
                 $result .= "\n";
             }
         } else {
+            // Top margin
+            for ($x = 0; $x < $this->margin; $x++) {
+                $result .= str_repeat($this->emptyBlock, $width + 2 * $this->margin)."\n";
+            }
             foreach ($array as $row) {
                 $result .= $margin; // left margin
                 foreach ($row as $byte) {
@@ -258,11 +265,11 @@ class Plain implements RendererInterface
                 $result .= $margin; // right margin
                 $result .= "\n";
             }
-        }
 
-        // Bottom margin
-        for ($x = 0; $x < $this->margin; $x++) {
-            $result .= str_repeat($this->emptyBlock, $width + 2 * $this->margin)."\n";
+            // Bottom margin
+            for ($x = 0; $x < $this->margin; $x++) {
+                $result .= str_repeat($this->emptyBlock, $width + 2 * $this->margin)."\n";
+            }
         }
 
         return $result;

--- a/src/BaconQrCode/Renderer/Text/Plain.php
+++ b/src/BaconQrCode/Renderer/Text/Plain.php
@@ -26,6 +26,13 @@ class Plain implements RendererInterface
     protected $margin = 1;
 
     /**
+     * Whether QR code render compact.
+     *
+     * @var boolean
+     */
+    protected $compact = false;
+
+    /**
      * Char used for full block.
      *
      * UTF-8 FULL BLOCK (U+2588)
@@ -34,6 +41,24 @@ class Plain implements RendererInterface
      * @link http://www.fileformat.info/info/unicode/char/2588/index.htm
      */
     protected $fullBlock = "\xE2\x96\x88";
+
+    /**
+     * Char used for upper half block.
+     *
+     * UTF-8 UPPER HALF BLOCK (U+2580)
+     * @var string
+     * @link http://www.fileformat.info/info/unicode/char/2580/index.htm
+     */
+    protected $upperHalfBlock = "\xE2\x96\x80";
+
+    /**
+     * Char used for lower half block.
+     *
+     * UTF-8 LOWER HALF BLOCK (U+2584)
+     * @var string
+     * @link http://www.fileformat.info/info/unicode/char/2584/index.htm
+     */
+    protected $lowerHalfBlock = "\xE2\x96\x84";
 
     /**
      * Char used for empty space
@@ -60,6 +85,46 @@ class Plain implements RendererInterface
     public function getFullBlock()
     {
         return $this->fullBlock;
+    }
+
+    /**
+     * Set char used as upper half block (upper half occupied space, lower half empty space).
+     *
+     * @param string $upperHalfBlock
+     */
+    public function setUpperHalfBlock($upperHalfBlock)
+    {
+        $this->upperHalfBlock = $upperHalfBlock;
+    }
+
+    /**
+     * Get char used as upper half block (upper half occupied space, lower half empty space).
+     *
+     * @return string
+     */
+    public function getUpperHalfBlock()
+    {
+        return $this->upperHalfBlock;
+    }
+
+    /**
+     * Set char used as lower half block (upper half empty space, lower half occupied space).
+     *
+     * @param string $lowerHalfBlock
+     */
+    public function setLowerHalfBlock($lowerHalfBlock)
+    {
+        $this->lowerHalfBlock = $lowerHalfBlock;
+    }
+
+    /**
+     * Get char used as lower half block (upper half empty space, lower half occupied space).
+     *
+     * @return string
+     */
+    public function getLowerHalfBlock()
+    {
+        return $this->lowerHalfBlock;
     }
 
     /**
@@ -111,6 +176,26 @@ class Plain implements RendererInterface
     }
 
     /**
+     * Sets whether QR code render compact.
+     *
+     * @param boolean $compact
+     */
+    public function setCompact($compact)
+    {
+        $this->compact = (bool)$compact;
+    }
+
+    /**
+     * Gets whether QR code render compact.
+     *
+     * @return boolean
+     */
+    public function getCompact()
+    {
+        return $this->compact;
+    }
+
+    /**
      * render(): defined by RendererInterface.
      *
      * @see    RendererInterface::render()
@@ -122,6 +207,7 @@ class Plain implements RendererInterface
         $result = '';
         $matrix = $qrCode->getMatrix();
         $width  = $matrix->getWidth();
+        $margin = str_repeat($this->emptyBlock, $this->margin);
 
         // Top margin
         for ($x = 0; $x < $this->margin; $x++) {
@@ -131,13 +217,47 @@ class Plain implements RendererInterface
         // Body
         $array = $matrix->getArray();
 
-        foreach ($array as $row) {
-            $result .= str_repeat($this->emptyBlock, $this->margin); // left margin
-            foreach ($row as $byte) {
-                $result .= $byte ? $this->fullBlock : $this->emptyBlock;
+        if ($this->compact) {
+            $len = $array->getSize();
+            $size = $array[0]->getSize();
+
+            // If not an even rows, fill an empty blocks row
+            if ($len % 2 !== 0) {
+                $array->setSize($len + 1);
+                for ($i = 0; $i < $size; $i++) {
+                    $array[$len][$i] = 0;
+                }
+                $len++;
             }
-            $result .= str_repeat($this->emptyBlock, $this->margin); // right margin
-            $result .= "\n";
+
+            for ($i = 0; $i < $len; $i++) {
+                // Each loop get 2 rows
+                $even = $array[$i];
+                $odd = $array[++$i];
+
+                $result .= $margin; // left margin
+                for ($j = 0; $j < $size; $j++) {
+                    $upper = $even[$j];
+                    $lower = $odd[$j];
+
+                    if ($upper) {
+                        $result .= $lower ? $this->fullBlock : $this->upperHalfBlock;
+                    } else {
+                        $result .= $lower ? $this->lowerHalfBlock : $this->emptyBlock;
+                    }
+                }
+                $result .= $margin; // right margin
+                $result .= "\n";
+            }
+        } else {
+            foreach ($array as $row) {
+                $result .= $margin; // left margin
+                foreach ($row as $byte) {
+                    $result .= $byte ? $this->fullBlock : $this->emptyBlock;
+                }
+                $result .= $margin; // right margin
+                $result .= "\n";
+            }
         }
 
         // Bottom margin

--- a/src/BaconQrCode/Renderer/Text/Plain.php
+++ b/src/BaconQrCode/Renderer/Text/Plain.php
@@ -227,10 +227,18 @@ class Plain implements RendererInterface
 
             $len = sizeof($array);
 
-            // If not an even rows, fill an empty blocks row
+            // In compact mode, render must be even rows.
             if ($len % 2 !== 0) {
-                $len++;
-                $array[] = $emptyRow;
+                if ($this->margin > 0) {
+                    // Because render last row will be end with newline("\n"), so if
+                    // also add an empty blocks row, it looks not 'compact'.
+                    $len--;
+                    array_pop($array);
+                } else {
+                    // If there are zero margin, fill an empty blocks row.
+                    $len++;
+                    $array[] = $emptyRow;
+                }
             }
 
             for ($i = 0; $i < $len; $i++) {

--- a/tests/BaconQrCode/Renderer/Text/TextTest.php
+++ b/tests/BaconQrCode/Renderer/Text/TextTest.php
@@ -69,35 +69,6 @@ class PlainTest extends TestCase
         $this->assertEquals($expected, $this->renderer->render($qrCode));
     }
 
-    public function testBaseCompactRender()
-    {
-        $content = 'foobar';
-        $expected =
-            "                       \n" .
-            " █▀▀▀▀▀█ ▀█▀█▀ █▀▀▀▀▀█ \n" .
-            " █ ███ █  ██▄  █ ███ █ \n" .
-            " █ ▀▀▀ █   ▀▄█ █ ▀▀▀ █ \n" .
-            " ▀▀▀▀▀▀▀ █▄█▄█ ▀▀▀▀▀▀▀ \n" .
-            " ▀▀ ██ ▀  ██ █ █ ▄▄  ▀ \n" .
-            "  ▀▀▀▀▀▀▀▀ █▄ ▀▀ ▀ ▄▀█ \n" .
-            "  ▀▀  ▀▀▀▄ █▄▄ ▀  █ ▄▀ \n" .
-            " █▀▀▀▀▀█  ▀█▄██▀▀▀█▄   \n" .
-            " █ ███ █ ██ ██ ▀█ █▄▀▀ \n" .
-            " █ ▀▀▀ █ ▄▄█  ▄█▄▀█▄██ \n" .
-            " ▀▀▀▀▀▀▀ ▀▀▀▀   ▀▀     \n" .
-            "                       \n"
-        ;
-
-        $qrCode = Encoder::encode(
-            $content,
-            new ErrorCorrectionLevel(ErrorCorrectionLevel::L),
-            Encoder::DEFAULT_BYTE_MODE_ECODING
-        );
-        $this->renderer->setCompact(true);
-        $this->assertEquals(true, $this->renderer->getCompact());
-        $this->assertEquals($expected, $this->renderer->render($qrCode));
-    }
-
     public function testBasicRenderNoMargins()
     {
         $content = 'foobar';
@@ -132,35 +103,6 @@ class PlainTest extends TestCase
         );
         $this->renderer->setMargin(0);
         $this->assertEquals(0, $this->renderer->getMargin());
-        $this->assertEquals($expected, $this->renderer->render($qrCode));
-    }
-
-    public function testBaseCompactRenderNoMargins()
-    {
-        $content = 'foobar';
-        $expected =
-            "█▀▀▀▀▀█ ▀█▀█▀ █▀▀▀▀▀█\n" .
-            "█ ███ █  ██▄  █ ███ █\n" .
-            "█ ▀▀▀ █   ▀▄█ █ ▀▀▀ █\n" .
-            "▀▀▀▀▀▀▀ █▄█▄█ ▀▀▀▀▀▀▀\n" .
-            "▀▀ ██ ▀  ██ █ █ ▄▄  ▀\n" .
-            " ▀▀▀▀▀▀▀▀ █▄ ▀▀ ▀ ▄▀█\n" .
-            " ▀▀  ▀▀▀▄ █▄▄ ▀  █ ▄▀\n" .
-            "█▀▀▀▀▀█  ▀█▄██▀▀▀█▄  \n" .
-            "█ ███ █ ██ ██ ▀█ █▄▀▀\n" .
-            "█ ▀▀▀ █ ▄▄█  ▄█▄▀█▄██\n" .
-            "▀▀▀▀▀▀▀ ▀▀▀▀   ▀▀    \n"
-        ;
-
-        $qrCode = Encoder::encode(
-            $content,
-            new ErrorCorrectionLevel(ErrorCorrectionLevel::L),
-            Encoder::DEFAULT_BYTE_MODE_ECODING
-        );
-        $this->renderer->setMargin(0);
-        $this->renderer->setCompact(true);
-        $this->assertEquals(0, $this->renderer->getMargin());
-        $this->assertEquals(true, $this->renderer->getCompact());
         $this->assertEquals($expected, $this->renderer->render($qrCode));
     }
 
@@ -205,22 +147,130 @@ class PlainTest extends TestCase
         $this->assertEquals($expected, $this->renderer->render($qrCode));
     }
 
+    public function testBaseCompactRender()
+    {
+        $content = 'foobar';
+        $expected =
+            " ▄▄▄▄▄▄▄ ▄▄▄▄▄ ▄▄▄▄▄▄▄ \n" .
+            " █ ▄▄▄ █  █▄▀  █ ▄▄▄ █ \n" .
+            " █ ███ █  ▀█▀▄ █ ███ █ \n" .
+            " █▄▄▄▄▄█ ▄ ▄▀█ █▄▄▄▄▄█ \n" .
+            " ▄▄ ▄▄ ▄ ▀██▀█ ▄     ▄ \n" .
+            "  ▄▄██▄▄▄▄▀█ ▀▄█ █▀ ▄▄ \n" .
+            "  ▄▄  ▄▄▄  █▀  ▄  ▄▀ █ \n" .
+            " ▄▄▄▄▄▄▄ ▀▄█▀█▄▄▄▄█ ▀  \n" .
+            " █ ▄▄▄ █ ▄▄▀██▀▄▄ █▀▄▄ \n" .
+            " █ ███ █ ▀▀▄▀▀ ▄▀▄█▀▄▄ \n" .
+            " █▄▄▄▄▄█ ███▄ ▀▀█▄▀▀▀▀ \n" .
+            "                       \n"
+        ;
+
+        $qrCode = Encoder::encode(
+            $content,
+            new ErrorCorrectionLevel(ErrorCorrectionLevel::L),
+            Encoder::DEFAULT_BYTE_MODE_ECODING
+        );
+        $this->renderer->setCompact(true);
+        $this->assertEquals(true, $this->renderer->getCompact());
+        $this->assertEquals($expected, $this->renderer->render($qrCode));
+    }
+
+    public function testBaseCompactRenderNoMargins()
+    {
+        $content = 'foobar';
+        $expected =
+            "█▀▀▀▀▀█ ▀█▀█▀ █▀▀▀▀▀█\n" .
+            "█ ███ █  ██▄  █ ███ █\n" .
+            "█ ▀▀▀ █   ▀▄█ █ ▀▀▀ █\n" .
+            "▀▀▀▀▀▀▀ █▄█▄█ ▀▀▀▀▀▀▀\n" .
+            "▀▀ ██ ▀  ██ █ █ ▄▄  ▀\n" .
+            " ▀▀▀▀▀▀▀▀ █▄ ▀▀ ▀ ▄▀█\n" .
+            " ▀▀  ▀▀▀▄ █▄▄ ▀  █ ▄▀\n" .
+            "█▀▀▀▀▀█  ▀█▄██▀▀▀█▄  \n" .
+            "█ ███ █ ██ ██ ▀█ █▄▀▀\n" .
+            "█ ▀▀▀ █ ▄▄█  ▄█▄▀█▄██\n" .
+            "▀▀▀▀▀▀▀ ▀▀▀▀   ▀▀    \n"
+        ;
+
+        $qrCode = Encoder::encode(
+            $content,
+            new ErrorCorrectionLevel(ErrorCorrectionLevel::L),
+            Encoder::DEFAULT_BYTE_MODE_ECODING
+        );
+        $this->renderer->setMargin(0);
+        $this->renderer->setCompact(true);
+        $this->assertEquals(0, $this->renderer->getMargin());
+        $this->assertEquals(true, $this->renderer->getCompact());
+        $this->assertEquals($expected, $this->renderer->render($qrCode));
+    }
+
+    public function testBaseCompactRenderWithMargins()
+    {
+        $content = 'foobar';
+        $expected2Margin =
+            "                         \n" .
+            "  █▀▀▀▀▀█ ▀█▀█▀ █▀▀▀▀▀█  \n" .
+            "  █ ███ █  ██▄  █ ███ █  \n" .
+            "  █ ▀▀▀ █   ▀▄█ █ ▀▀▀ █  \n" .
+            "  ▀▀▀▀▀▀▀ █▄█▄█ ▀▀▀▀▀▀▀  \n" .
+            "  ▀▀ ██ ▀  ██ █ █ ▄▄  ▀  \n" .
+            "   ▀▀▀▀▀▀▀▀ █▄ ▀▀ ▀ ▄▀█  \n" .
+            "   ▀▀  ▀▀▀▄ █▄▄ ▀  █ ▄▀  \n" .
+            "  █▀▀▀▀▀█  ▀█▄██▀▀▀█▄    \n" .
+            "  █ ███ █ ██ ██ ▀█ █▄▀▀  \n" .
+            "  █ ▀▀▀ █ ▄▄█  ▄█▄▀█▄██  \n" .
+            "  ▀▀▀▀▀▀▀ ▀▀▀▀   ▀▀      \n" .
+            "                         \n"
+        ;
+
+        $expected3Margin =
+            "                           \n" .
+            "   ▄▄▄▄▄▄▄ ▄▄▄▄▄ ▄▄▄▄▄▄▄   \n" .
+            "   █ ▄▄▄ █  █▄▀  █ ▄▄▄ █   \n" .
+            "   █ ███ █  ▀█▀▄ █ ███ █   \n" .
+            "   █▄▄▄▄▄█ ▄ ▄▀█ █▄▄▄▄▄█   \n" .
+            "   ▄▄ ▄▄ ▄ ▀██▀█ ▄     ▄   \n" .
+            "    ▄▄██▄▄▄▄▀█ ▀▄█ █▀ ▄▄   \n" .
+            "    ▄▄  ▄▄▄  █▀  ▄  ▄▀ █   \n" .
+            "   ▄▄▄▄▄▄▄ ▀▄█▀█▄▄▄▄█ ▀    \n" .
+            "   █ ▄▄▄ █ ▄▄▀██▀▄▄ █▀▄▄   \n" .
+            "   █ ███ █ ▀▀▄▀▀ ▄▀▄█▀▄▄   \n" .
+            "   █▄▄▄▄▄█ ███▄ ▀▀█▄▀▀▀▀   \n" .
+            "                           \n" .
+            "                           \n"
+        ;
+
+        $qrCode = Encoder::encode(
+            $content,
+            new ErrorCorrectionLevel(ErrorCorrectionLevel::L),
+            Encoder::DEFAULT_BYTE_MODE_ECODING
+        );
+        $this->renderer->setMargin(2);
+        $this->renderer->setCompact(true);
+        $this->assertEquals(2, $this->renderer->getMargin());
+        $this->assertEquals(true, $this->renderer->getCompact());
+        $this->assertEquals($expected2Margin, $this->renderer->render($qrCode));
+
+        $this->renderer->setMargin(3);
+        $this->assertEquals(3, $this->renderer->getMargin());
+        $this->assertEquals($expected3Margin, $this->renderer->render($qrCode));
+    }
+
     public function testBaseCompactRenderCustomChar()
     {
         $content = 'foobar';
         $expected =
-            ".......................\n" .
-            ".#¯¯¯¯¯#.¯#¯#¯.#¯¯¯¯¯#.\n" .
-            ".#.###.#..##_..#.###.#.\n" .
-            ".#.¯¯¯.#...¯_#.#.¯¯¯.#.\n" .
-            ".¯¯¯¯¯¯¯.#_#_#.¯¯¯¯¯¯¯.\n" .
-            ".¯¯.##.¯..##.#.#.__..¯.\n" .
-            "..¯¯¯¯¯¯¯¯.#_.¯¯.¯._¯#.\n" .
-            "..¯¯..¯¯¯_.#__.¯..#._¯.\n" .
-            ".#¯¯¯¯¯#..¯#_##¯¯¯#_...\n" .
-            ".#.###.#.##.##.¯#.#_¯¯.\n" .
-            ".#.¯¯¯.#.__#.._#_¯#_##.\n" .
-            ".¯¯¯¯¯¯¯.¯¯¯¯...¯¯.....\n" .
+            "._______._____._______.\n" .
+            ".#.___.#..#_¯..#.___.#.\n" .
+            ".#.###.#..¯#¯_.#.###.#.\n" .
+            ".#_____#._._¯#.#_____#.\n" .
+            ".__.__._.¯##¯#._....._.\n" .
+            "..__##____¯#.¯_#.#¯.__.\n" .
+            "..__..___..#¯.._.._¯.#.\n" .
+            "._______.¯_#¯#____#.¯..\n" .
+            ".#.___.#.__¯##¯__.#¯__.\n" .
+            ".#.###.#.¯¯_¯¯._¯_#¯__.\n" .
+            ".#_____#.###_.¯¯#_¯¯¯¯.\n" .
             ".......................\n"
         ;
 

--- a/tests/BaconQrCode/Renderer/Text/TextTest.php
+++ b/tests/BaconQrCode/Renderer/Text/TextTest.php
@@ -32,263 +32,220 @@ class PlainTest extends TestCase
         $this->writer = new Writer($this->renderer);
     }
 
-    public function testBasicRender()
+    public function additionProvider()
     {
-        $content = 'foobar';
-        $expected =
-            "                       \n" .
-            " ███████ █████ ███████ \n" .
-            " █     █  █ █  █     █ \n" .
-            " █ ███ █  ██   █ ███ █ \n" .
-            " █ ███ █  ███  █ ███ █ \n" .
-            " █ ███ █   █ █ █ ███ █ \n" .
-            " █     █    ██ █     █ \n" .
-            " ███████ █ █ █ ███████ \n" .
-            "         █████         \n" .
-            " ██ ██ █  ██ █ █     █ \n" .
-            "    ██    ██ █ █ ██    \n" .
-            "  ████████ █  ██ █  ██ \n" .
-            "           ██      █ █ \n" .
-            "  ██  ███  █   █  █  █ \n" .
-            "         █ ███    █ █  \n" .
-            " ███████  ██ ██████    \n" .
-            " █     █   ████   ██   \n" .
-            " █ ███ █ ██ ██ ██ █ ██ \n" .
-            " █ ███ █ ██ ██  █ ██   \n" .
-            " █ ███ █   █   █ ██ ██ \n" .
-            " █     █ ███  ███ ████ \n" .
-            " ███████ ████   ██     \n" .
-            "                       \n"
-        ;
-
-        $qrCode = Encoder::encode(
-            $content,
-            new ErrorCorrectionLevel(ErrorCorrectionLevel::L),
-            Encoder::DEFAULT_BYTE_MODE_ECODING
+        return array(
+            array(
+                "                       \n" .
+                " ███████ █████ ███████ \n" .
+                " █     █  █ █  █     █ \n" .
+                " █ ███ █  ██   █ ███ █ \n" .
+                " █ ███ █  ███  █ ███ █ \n" .
+                " █ ███ █   █ █ █ ███ █ \n" .
+                " █     █    ██ █     █ \n" .
+                " ███████ █ █ █ ███████ \n" .
+                "         █████         \n" .
+                " ██ ██ █  ██ █ █     █ \n" .
+                "    ██    ██ █ █ ██    \n" .
+                "  ████████ █  ██ █  ██ \n" .
+                "           ██      █ █ \n" .
+                "  ██  ███  █   █  █  █ \n" .
+                "         █ ███    █ █  \n" .
+                " ███████  ██ ██████    \n" .
+                " █     █   ████   ██   \n" .
+                " █ ███ █ ██ ██ ██ █ ██ \n" .
+                " █ ███ █ ██ ██  █ ██   \n" .
+                " █ ███ █   █   █ ██ ██ \n" .
+                " █     █ ███  ███ ████ \n" .
+                " ███████ ████   ██     \n" .
+                "                       \n"
+            ),
+            array(
+                "███████ █████ ███████\n" .
+                "█     █  █ █  █     █\n" .
+                "█ ███ █  ██   █ ███ █\n" .
+                "█ ███ █  ███  █ ███ █\n" .
+                "█ ███ █   █ █ █ ███ █\n" .
+                "█     █    ██ █     █\n" .
+                "███████ █ █ █ ███████\n" .
+                "        █████        \n" .
+                "██ ██ █  ██ █ █     █\n" .
+                "   ██    ██ █ █ ██   \n" .
+                " ████████ █  ██ █  ██\n" .
+                "          ██      █ █\n" .
+                " ██  ███  █   █  █  █\n" .
+                "        █ ███    █ █ \n" .
+                "███████  ██ ██████   \n" .
+                "█     █   ████   ██  \n" .
+                "█ ███ █ ██ ██ ██ █ ██\n" .
+                "█ ███ █ ██ ██  █ ██  \n" .
+                "█ ███ █   █   █ ██ ██\n" .
+                "█     █ ███  ███ ████\n" .
+                "███████ ████   ██    \n",
+                false,
+                0
+            ),
+            array(
+                "-----------------------\n" .
+                "-#######-#####-#######-\n" .
+                "-#-----#--#-#--#-----#-\n" .
+                "-#-###-#--##---#-###-#-\n" .
+                "-#-###-#--###--#-###-#-\n" .
+                "-#-###-#---#-#-#-###-#-\n" .
+                "-#-----#----##-#-----#-\n" .
+                "-#######-#-#-#-#######-\n" .
+                "---------#####---------\n" .
+                "-##-##-#--##-#-#-----#-\n" .
+                "----##----##-#-#-##----\n" .
+                "--########-#--##-#--##-\n" .
+                "-----------##------#-#-\n" .
+                "--##--###--#---#--#--#-\n" .
+                "---------#-###----#-#--\n" .
+                "-#######--##-######----\n" .
+                "-#-----#---####---##---\n" .
+                "-#-###-#-##-##-##-#-##-\n" .
+                "-#-###-#-##-##--#-##---\n" .
+                "-#-###-#---#---#-##-##-\n" .
+                "-#-----#-###--###-####-\n" .
+                "-#######-####---##-----\n" .
+                "-----------------------\n",
+                false,
+                1,
+                array(
+                    'fullBlock' => '#',
+                    'emptyBlock' => '-'
+                )
+            ),
+            array(
+                " ▄▄▄▄▄▄▄ ▄▄▄▄▄ ▄▄▄▄▄▄▄ \n" .
+                " █ ▄▄▄ █  █▄▀  █ ▄▄▄ █ \n" .
+                " █ ███ █  ▀█▀▄ █ ███ █ \n" .
+                " █▄▄▄▄▄█ ▄ ▄▀█ █▄▄▄▄▄█ \n" .
+                " ▄▄ ▄▄ ▄ ▀██▀█ ▄     ▄ \n" .
+                "  ▄▄██▄▄▄▄▀█ ▀▄█ █▀ ▄▄ \n" .
+                "  ▄▄  ▄▄▄  █▀  ▄  ▄▀ █ \n" .
+                " ▄▄▄▄▄▄▄ ▀▄█▀█▄▄▄▄█ ▀  \n" .
+                " █ ▄▄▄ █ ▄▄▀██▀▄▄ █▀▄▄ \n" .
+                " █ ███ █ ▀▀▄▀▀ ▄▀▄█▀▄▄ \n" .
+                " █▄▄▄▄▄█ ███▄ ▀▀█▄▀▀▀▀ \n",
+                true
+            ),
+            array(
+                "█▀▀▀▀▀█ ▀█▀█▀ █▀▀▀▀▀█\n" .
+                "█ ███ █  ██▄  █ ███ █\n" .
+                "█ ▀▀▀ █   ▀▄█ █ ▀▀▀ █\n" .
+                "▀▀▀▀▀▀▀ █▄█▄█ ▀▀▀▀▀▀▀\n" .
+                "▀▀ ██ ▀  ██ █ █ ▄▄  ▀\n" .
+                " ▀▀▀▀▀▀▀▀ █▄ ▀▀ ▀ ▄▀█\n" .
+                " ▀▀  ▀▀▀▄ █▄▄ ▀  █ ▄▀\n" .
+                "█▀▀▀▀▀█  ▀█▄██▀▀▀█▄  \n" .
+                "█ ███ █ ██ ██ ▀█ █▄▀▀\n" .
+                "█ ▀▀▀ █ ▄▄█  ▄█▄▀█▄██\n" .
+                "▀▀▀▀▀▀▀ ▀▀▀▀   ▀▀    \n",
+                true,
+                0
+            ),
+            array(
+                "                         \n" .
+                "  █▀▀▀▀▀█ ▀█▀█▀ █▀▀▀▀▀█  \n" .
+                "  █ ███ █  ██▄  █ ███ █  \n" .
+                "  █ ▀▀▀ █   ▀▄█ █ ▀▀▀ █  \n" .
+                "  ▀▀▀▀▀▀▀ █▄█▄█ ▀▀▀▀▀▀▀  \n" .
+                "  ▀▀ ██ ▀  ██ █ █ ▄▄  ▀  \n" .
+                "   ▀▀▀▀▀▀▀▀ █▄ ▀▀ ▀ ▄▀█  \n" .
+                "   ▀▀  ▀▀▀▄ █▄▄ ▀  █ ▄▀  \n" .
+                "  █▀▀▀▀▀█  ▀█▄██▀▀▀█▄    \n" .
+                "  █ ███ █ ██ ██ ▀█ █▄▀▀  \n" .
+                "  █ ▀▀▀ █ ▄▄█  ▄█▄▀█▄██  \n" .
+                "  ▀▀▀▀▀▀▀ ▀▀▀▀   ▀▀      \n",
+                true,
+                2
+            ),
+            array(
+                "                           \n" .
+                "   ▄▄▄▄▄▄▄ ▄▄▄▄▄ ▄▄▄▄▄▄▄   \n" .
+                "   █ ▄▄▄ █  █▄▀  █ ▄▄▄ █   \n" .
+                "   █ ███ █  ▀█▀▄ █ ███ █   \n" .
+                "   █▄▄▄▄▄█ ▄ ▄▀█ █▄▄▄▄▄█   \n" .
+                "   ▄▄ ▄▄ ▄ ▀██▀█ ▄     ▄   \n" .
+                "    ▄▄██▄▄▄▄▀█ ▀▄█ █▀ ▄▄   \n" .
+                "    ▄▄  ▄▄▄  █▀  ▄  ▄▀ █   \n" .
+                "   ▄▄▄▄▄▄▄ ▀▄█▀█▄▄▄▄█ ▀    \n" .
+                "   █ ▄▄▄ █ ▄▄▀██▀▄▄ █▀▄▄   \n" .
+                "   █ ███ █ ▀▀▄▀▀ ▄▀▄█▀▄▄   \n" .
+                "   █▄▄▄▄▄█ ███▄ ▀▀█▄▀▀▀▀   \n" .
+                "                           \n",
+                true,
+                3
+            ),
+            array(
+                "._______._____._______.\n" .
+                ".#.___.#..#_¯..#.___.#.\n" .
+                ".#.###.#..¯#¯_.#.###.#.\n" .
+                ".#_____#._._¯#.#_____#.\n" .
+                ".__.__._.¯##¯#._....._.\n" .
+                "..__##____¯#.¯_#.#¯.__.\n" .
+                "..__..___..#¯.._.._¯.#.\n" .
+                "._______.¯_#¯#____#.¯..\n" .
+                ".#.___.#.__¯##¯__.#¯__.\n" .
+                ".#.###.#.¯¯_¯¯._¯_#¯__.\n" .
+                ".#_____#.###_.¯¯#_¯¯¯¯.\n",
+                true,
+                1,
+                array(
+                    'fullBlock' => '#',
+                    'emptyBlock' => '.',
+                    'upplerHalfBlock' => '¯',
+                    'lowerHalfBlock' => '_'
+                )
+            ),
         );
-        $this->assertEquals($expected, $this->renderer->render($qrCode));
     }
 
-    public function testBasicRenderNoMargins()
-    {
-        $content = 'foobar';
-        $expected =
-            "███████ █████ ███████\n" .
-            "█     █  █ █  █     █\n" .
-            "█ ███ █  ██   █ ███ █\n" .
-            "█ ███ █  ███  █ ███ █\n" .
-            "█ ███ █   █ █ █ ███ █\n" .
-            "█     █    ██ █     █\n" .
-            "███████ █ █ █ ███████\n" .
-            "        █████        \n" .
-            "██ ██ █  ██ █ █     █\n" .
-            "   ██    ██ █ █ ██   \n" .
-            " ████████ █  ██ █  ██\n" .
-            "          ██      █ █\n" .
-            " ██  ███  █   █  █  █\n" .
-            "        █ ███    █ █ \n" .
-            "███████  ██ ██████   \n" .
-            "█     █   ████   ██  \n" .
-            "█ ███ █ ██ ██ ██ █ ██\n" .
-            "█ ███ █ ██ ██  █ ██  \n" .
-            "█ ███ █   █   █ ██ ██\n" .
-            "█     █ ███  ███ ████\n" .
-            "███████ ████   ██    \n"
-        ;
-
+    /**
+     * @dataProvider additionProvider
+     */
+    public function testTextRender(
+        $expected,
+        $compact = false,
+        $margin = 1,
+        array $blocks = array(),
+        $content = 'foobar'
+    ) {
         $qrCode = Encoder::encode(
             $content,
             new ErrorCorrectionLevel(ErrorCorrectionLevel::L),
             Encoder::DEFAULT_BYTE_MODE_ECODING
         );
-        $this->renderer->setMargin(0);
-        $this->assertEquals(0, $this->renderer->getMargin());
-        $this->assertEquals($expected, $this->renderer->render($qrCode));
-    }
 
-    public function testBasicRenderCustomChar()
-    {
-        $content = 'foobar';
-        $expected =
-            "-----------------------\n" .
-            "-#######-#####-#######-\n" .
-            "-#-----#--#-#--#-----#-\n" .
-            "-#-###-#--##---#-###-#-\n" .
-            "-#-###-#--###--#-###-#-\n" .
-            "-#-###-#---#-#-#-###-#-\n" .
-            "-#-----#----##-#-----#-\n" .
-            "-#######-#-#-#-#######-\n" .
-            "---------#####---------\n" .
-            "-##-##-#--##-#-#-----#-\n" .
-            "----##----##-#-#-##----\n" .
-            "--########-#--##-#--##-\n" .
-            "-----------##------#-#-\n" .
-            "--##--###--#---#--#--#-\n" .
-            "---------#-###----#-#--\n" .
-            "-#######--##-######----\n" .
-            "-#-----#---####---##---\n" .
-            "-#-###-#-##-##-##-#-##-\n" .
-            "-#-###-#-##-##--#-##---\n" .
-            "-#-###-#---#---#-##-##-\n" .
-            "-#-----#-###--###-####-\n" .
-            "-#######-####---##-----\n" .
-            "-----------------------\n"
-        ;
+        $this->renderer->setCompact($compact);
+        $this->assertEquals((boolean)$compact, $this->renderer->getCompact());
 
-        $qrCode = Encoder::encode(
-            $content,
-            new ErrorCorrectionLevel(ErrorCorrectionLevel::L),
-            Encoder::DEFAULT_BYTE_MODE_ECODING
-        );
-        $this->renderer->setFullBlock('#');
-        $this->renderer->setEmptyBlock('-');
-        $this->assertEquals('#', $this->renderer->getFullBlock());
-        $this->assertEquals('-', $this->renderer->getEmptyBlock());
-        $this->assertEquals($expected, $this->renderer->render($qrCode));
-    }
+        $this->renderer->setMargin($margin);
+        $this->assertEquals($margin, $this->renderer->getMargin());
 
-    public function testBaseCompactRender()
-    {
-        $content = 'foobar';
-        $expected =
-            " ▄▄▄▄▄▄▄ ▄▄▄▄▄ ▄▄▄▄▄▄▄ \n" .
-            " █ ▄▄▄ █  █▄▀  █ ▄▄▄ █ \n" .
-            " █ ███ █  ▀█▀▄ █ ███ █ \n" .
-            " █▄▄▄▄▄█ ▄ ▄▀█ █▄▄▄▄▄█ \n" .
-            " ▄▄ ▄▄ ▄ ▀██▀█ ▄     ▄ \n" .
-            "  ▄▄██▄▄▄▄▀█ ▀▄█ █▀ ▄▄ \n" .
-            "  ▄▄  ▄▄▄  █▀  ▄  ▄▀ █ \n" .
-            " ▄▄▄▄▄▄▄ ▀▄█▀█▄▄▄▄█ ▀  \n" .
-            " █ ▄▄▄ █ ▄▄▀██▀▄▄ █▀▄▄ \n" .
-            " █ ███ █ ▀▀▄▀▀ ▄▀▄█▀▄▄ \n" .
-            " █▄▄▄▄▄█ ███▄ ▀▀█▄▀▀▀▀ \n" .
-            "                       \n"
-        ;
+        if (!empty($blocks)) {
+            if (isset($blocks['fullBlock'])) {
+                $this->renderer->setFullBlock($blocks['fullBlock']);
+                $this->assertEquals($blocks['fullBlock'], $this->renderer->getFullBlock());
+            }
 
-        $qrCode = Encoder::encode(
-            $content,
-            new ErrorCorrectionLevel(ErrorCorrectionLevel::L),
-            Encoder::DEFAULT_BYTE_MODE_ECODING
-        );
-        $this->renderer->setCompact(true);
-        $this->assertEquals(true, $this->renderer->getCompact());
-        $this->assertEquals($expected, $this->renderer->render($qrCode));
-    }
+            if (isset($blocks['emptyBlock'])) {
+                $this->renderer->setEmptyBlock($blocks['emptyBlock']);
+                $this->assertEquals($blocks['emptyBlock'], $this->renderer->getEmptyBlock());
+            }
 
-    public function testBaseCompactRenderNoMargins()
-    {
-        $content = 'foobar';
-        $expected =
-            "█▀▀▀▀▀█ ▀█▀█▀ █▀▀▀▀▀█\n" .
-            "█ ███ █  ██▄  █ ███ █\n" .
-            "█ ▀▀▀ █   ▀▄█ █ ▀▀▀ █\n" .
-            "▀▀▀▀▀▀▀ █▄█▄█ ▀▀▀▀▀▀▀\n" .
-            "▀▀ ██ ▀  ██ █ █ ▄▄  ▀\n" .
-            " ▀▀▀▀▀▀▀▀ █▄ ▀▀ ▀ ▄▀█\n" .
-            " ▀▀  ▀▀▀▄ █▄▄ ▀  █ ▄▀\n" .
-            "█▀▀▀▀▀█  ▀█▄██▀▀▀█▄  \n" .
-            "█ ███ █ ██ ██ ▀█ █▄▀▀\n" .
-            "█ ▀▀▀ █ ▄▄█  ▄█▄▀█▄██\n" .
-            "▀▀▀▀▀▀▀ ▀▀▀▀   ▀▀    \n"
-        ;
+            if (isset($blocks['upplerHalfBlock'])) {
+                $this->renderer->setUpperHalfBlock($blocks['upplerHalfBlock']);
+                $this->assertEquals($blocks['upplerHalfBlock'], $this->renderer->getUpperHalfBlock());
+            }
 
-        $qrCode = Encoder::encode(
-            $content,
-            new ErrorCorrectionLevel(ErrorCorrectionLevel::L),
-            Encoder::DEFAULT_BYTE_MODE_ECODING
-        );
-        $this->renderer->setMargin(0);
-        $this->renderer->setCompact(true);
-        $this->assertEquals(0, $this->renderer->getMargin());
-        $this->assertEquals(true, $this->renderer->getCompact());
-        $this->assertEquals($expected, $this->renderer->render($qrCode));
-    }
+            if (isset($blocks['lowerHalfBlock'])) {
+                $this->renderer->setLowerHalfBlock($blocks['lowerHalfBlock']);
+                $this->assertEquals($blocks['lowerHalfBlock'], $this->renderer->getLowerHalfBlock());
+            }
+        }
 
-    public function testBaseCompactRenderWithMargins()
-    {
-        $content = 'foobar';
-        $expected2Margin =
-            "                         \n" .
-            "  █▀▀▀▀▀█ ▀█▀█▀ █▀▀▀▀▀█  \n" .
-            "  █ ███ █  ██▄  █ ███ █  \n" .
-            "  █ ▀▀▀ █   ▀▄█ █ ▀▀▀ █  \n" .
-            "  ▀▀▀▀▀▀▀ █▄█▄█ ▀▀▀▀▀▀▀  \n" .
-            "  ▀▀ ██ ▀  ██ █ █ ▄▄  ▀  \n" .
-            "   ▀▀▀▀▀▀▀▀ █▄ ▀▀ ▀ ▄▀█  \n" .
-            "   ▀▀  ▀▀▀▄ █▄▄ ▀  █ ▄▀  \n" .
-            "  █▀▀▀▀▀█  ▀█▄██▀▀▀█▄    \n" .
-            "  █ ███ █ ██ ██ ▀█ █▄▀▀  \n" .
-            "  █ ▀▀▀ █ ▄▄█  ▄█▄▀█▄██  \n" .
-            "  ▀▀▀▀▀▀▀ ▀▀▀▀   ▀▀      \n" .
-            "                         \n"
-        ;
-
-        $expected3Margin =
-            "                           \n" .
-            "   ▄▄▄▄▄▄▄ ▄▄▄▄▄ ▄▄▄▄▄▄▄   \n" .
-            "   █ ▄▄▄ █  █▄▀  █ ▄▄▄ █   \n" .
-            "   █ ███ █  ▀█▀▄ █ ███ █   \n" .
-            "   █▄▄▄▄▄█ ▄ ▄▀█ █▄▄▄▄▄█   \n" .
-            "   ▄▄ ▄▄ ▄ ▀██▀█ ▄     ▄   \n" .
-            "    ▄▄██▄▄▄▄▀█ ▀▄█ █▀ ▄▄   \n" .
-            "    ▄▄  ▄▄▄  █▀  ▄  ▄▀ █   \n" .
-            "   ▄▄▄▄▄▄▄ ▀▄█▀█▄▄▄▄█ ▀    \n" .
-            "   █ ▄▄▄ █ ▄▄▀██▀▄▄ █▀▄▄   \n" .
-            "   █ ███ █ ▀▀▄▀▀ ▄▀▄█▀▄▄   \n" .
-            "   █▄▄▄▄▄█ ███▄ ▀▀█▄▀▀▀▀   \n" .
-            "                           \n" .
-            "                           \n"
-        ;
-
-        $qrCode = Encoder::encode(
-            $content,
-            new ErrorCorrectionLevel(ErrorCorrectionLevel::L),
-            Encoder::DEFAULT_BYTE_MODE_ECODING
-        );
-        $this->renderer->setMargin(2);
-        $this->renderer->setCompact(true);
-        $this->assertEquals(2, $this->renderer->getMargin());
-        $this->assertEquals(true, $this->renderer->getCompact());
-        $this->assertEquals($expected2Margin, $this->renderer->render($qrCode));
-
-        $this->renderer->setMargin(3);
-        $this->assertEquals(3, $this->renderer->getMargin());
-        $this->assertEquals($expected3Margin, $this->renderer->render($qrCode));
-    }
-
-    public function testBaseCompactRenderCustomChar()
-    {
-        $content = 'foobar';
-        $expected =
-            "._______._____._______.\n" .
-            ".#.___.#..#_¯..#.___.#.\n" .
-            ".#.###.#..¯#¯_.#.###.#.\n" .
-            ".#_____#._._¯#.#_____#.\n" .
-            ".__.__._.¯##¯#._....._.\n" .
-            "..__##____¯#.¯_#.#¯.__.\n" .
-            "..__..___..#¯.._.._¯.#.\n" .
-            "._______.¯_#¯#____#.¯..\n" .
-            ".#.___.#.__¯##¯__.#¯__.\n" .
-            ".#.###.#.¯¯_¯¯._¯_#¯__.\n" .
-            ".#_____#.###_.¯¯#_¯¯¯¯.\n" .
-            ".......................\n"
-        ;
-
-        $qrCode = Encoder::encode(
-            $content,
-            new ErrorCorrectionLevel(ErrorCorrectionLevel::L),
-            Encoder::DEFAULT_BYTE_MODE_ECODING
-        );
-        $this->renderer->setCompact(true);
-        $this->renderer->setFullBlock('#');
-        $this->renderer->setEmptyBlock('.');
-        $this->renderer->setUpperHalfBlock('¯');
-        $this->renderer->setLowerHalfBlock('_');
-        $this->assertEquals(true, $this->renderer->getCompact());
-        $this->assertEquals('#', $this->renderer->getFullBlock());
-        $this->assertEquals('.', $this->renderer->getEmptyBlock());
-        $this->assertEquals('¯', $this->renderer->getUpperHalfBlock());
-        $this->assertEquals('_', $this->renderer->getLowerHalfBlock());
         $this->assertEquals($expected, $this->renderer->render($qrCode));
     }
 }

--- a/tests/BaconQrCode/Renderer/Text/TextTest.php
+++ b/tests/BaconQrCode/Renderer/Text/TextTest.php
@@ -69,6 +69,35 @@ class PlainTest extends TestCase
         $this->assertEquals($expected, $this->renderer->render($qrCode));
     }
 
+    public function testBaseCompactRender()
+    {
+        $content = 'foobar';
+        $expected =
+            "                       \n" .
+            " █▀▀▀▀▀█ ▀█▀█▀ █▀▀▀▀▀█ \n" .
+            " █ ███ █  ██▄  █ ███ █ \n" .
+            " █ ▀▀▀ █   ▀▄█ █ ▀▀▀ █ \n" .
+            " ▀▀▀▀▀▀▀ █▄█▄█ ▀▀▀▀▀▀▀ \n" .
+            " ▀▀ ██ ▀  ██ █ █ ▄▄  ▀ \n" .
+            "  ▀▀▀▀▀▀▀▀ █▄ ▀▀ ▀ ▄▀█ \n" .
+            "  ▀▀  ▀▀▀▄ █▄▄ ▀  █ ▄▀ \n" .
+            " █▀▀▀▀▀█  ▀█▄██▀▀▀█▄   \n" .
+            " █ ███ █ ██ ██ ▀█ █▄▀▀ \n" .
+            " █ ▀▀▀ █ ▄▄█  ▄█▄▀█▄██ \n" .
+            " ▀▀▀▀▀▀▀ ▀▀▀▀   ▀▀     \n" .
+            "                       \n"
+        ;
+
+        $qrCode = Encoder::encode(
+            $content,
+            new ErrorCorrectionLevel(ErrorCorrectionLevel::L),
+            Encoder::DEFAULT_BYTE_MODE_ECODING
+        );
+        $this->renderer->setCompact(true);
+        $this->assertEquals(true, $this->renderer->getCompact());
+        $this->assertEquals($expected, $this->renderer->render($qrCode));
+    }
+
     public function testBasicRenderNoMargins()
     {
         $content = 'foobar';
@@ -103,6 +132,35 @@ class PlainTest extends TestCase
         );
         $this->renderer->setMargin(0);
         $this->assertEquals(0, $this->renderer->getMargin());
+        $this->assertEquals($expected, $this->renderer->render($qrCode));
+    }
+
+    public function testBaseCompactRenderNoMargins()
+    {
+        $content = 'foobar';
+        $expected =
+            "█▀▀▀▀▀█ ▀█▀█▀ █▀▀▀▀▀█\n" .
+            "█ ███ █  ██▄  █ ███ █\n" .
+            "█ ▀▀▀ █   ▀▄█ █ ▀▀▀ █\n" .
+            "▀▀▀▀▀▀▀ █▄█▄█ ▀▀▀▀▀▀▀\n" .
+            "▀▀ ██ ▀  ██ █ █ ▄▄  ▀\n" .
+            " ▀▀▀▀▀▀▀▀ █▄ ▀▀ ▀ ▄▀█\n" .
+            " ▀▀  ▀▀▀▄ █▄▄ ▀  █ ▄▀\n" .
+            "█▀▀▀▀▀█  ▀█▄██▀▀▀█▄  \n" .
+            "█ ███ █ ██ ██ ▀█ █▄▀▀\n" .
+            "█ ▀▀▀ █ ▄▄█  ▄█▄▀█▄██\n" .
+            "▀▀▀▀▀▀▀ ▀▀▀▀   ▀▀    \n"
+        ;
+
+        $qrCode = Encoder::encode(
+            $content,
+            new ErrorCorrectionLevel(ErrorCorrectionLevel::L),
+            Encoder::DEFAULT_BYTE_MODE_ECODING
+        );
+        $this->renderer->setMargin(0);
+        $this->renderer->setCompact(true);
+        $this->assertEquals(0, $this->renderer->getMargin());
+        $this->assertEquals(true, $this->renderer->getCompact());
         $this->assertEquals($expected, $this->renderer->render($qrCode));
     }
 
@@ -144,6 +202,43 @@ class PlainTest extends TestCase
         $this->renderer->setEmptyBlock('-');
         $this->assertEquals('#', $this->renderer->getFullBlock());
         $this->assertEquals('-', $this->renderer->getEmptyBlock());
+        $this->assertEquals($expected, $this->renderer->render($qrCode));
+    }
+
+    public function testBaseCompactRenderCustomChar()
+    {
+        $content = 'foobar';
+        $expected =
+            ".......................\n" .
+            ".#¯¯¯¯¯#.¯#¯#¯.#¯¯¯¯¯#.\n" .
+            ".#.###.#..##_..#.###.#.\n" .
+            ".#.¯¯¯.#...¯_#.#.¯¯¯.#.\n" .
+            ".¯¯¯¯¯¯¯.#_#_#.¯¯¯¯¯¯¯.\n" .
+            ".¯¯.##.¯..##.#.#.__..¯.\n" .
+            "..¯¯¯¯¯¯¯¯.#_.¯¯.¯._¯#.\n" .
+            "..¯¯..¯¯¯_.#__.¯..#._¯.\n" .
+            ".#¯¯¯¯¯#..¯#_##¯¯¯#_...\n" .
+            ".#.###.#.##.##.¯#.#_¯¯.\n" .
+            ".#.¯¯¯.#.__#.._#_¯#_##.\n" .
+            ".¯¯¯¯¯¯¯.¯¯¯¯...¯¯.....\n" .
+            ".......................\n"
+        ;
+
+        $qrCode = Encoder::encode(
+            $content,
+            new ErrorCorrectionLevel(ErrorCorrectionLevel::L),
+            Encoder::DEFAULT_BYTE_MODE_ECODING
+        );
+        $this->renderer->setCompact(true);
+        $this->renderer->setFullBlock('#');
+        $this->renderer->setEmptyBlock('.');
+        $this->renderer->setUpperHalfBlock('¯');
+        $this->renderer->setLowerHalfBlock('_');
+        $this->assertEquals(true, $this->renderer->getCompact());
+        $this->assertEquals('#', $this->renderer->getFullBlock());
+        $this->assertEquals('.', $this->renderer->getEmptyBlock());
+        $this->assertEquals('¯', $this->renderer->getUpperHalfBlock());
+        $this->assertEquals('_', $this->renderer->getLowerHalfBlock());
         $this->assertEquals($expected, $this->renderer->render($qrCode));
     }
 }


### PR DESCRIPTION
Add a compact option on Text renderer.

e.g. foobar QR code
![qrcode](https://cloud.githubusercontent.com/assets/1174105/21016060/37a0c374-bd9f-11e6-8b04-d1dffb7f195e.png "foobar QR code in compact text")

