### PR TITLE
use modern PHPUnit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ php:
   - 5.6
   - 7.0
   - 7.1
+  - nightly
   - hhvm
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,10 @@ php:
   - nightly
   - hhvm
 
+matrix:
+  allow_failures:
+    - php: hhvm
+
 install:
   - travis_retry composer install --no-interaction
   - composer info -i

--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,6 @@
         }
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8"
+        "phpunit/phpunit": "^4.8.35|^5.7|^6.0"
     }
 }

--- a/tests/BaconQrCode/Common/BitArrayTest.php
+++ b/tests/BaconQrCode/Common/BitArrayTest.php
@@ -9,7 +9,7 @@
 
 namespace BaconQrCode\Common;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase as TestCase;
 
 class BitArrayTest extends TestCase
 {

--- a/tests/BaconQrCode/Common/BitMatrixTest.php
+++ b/tests/BaconQrCode/Common/BitMatrixTest.php
@@ -9,7 +9,7 @@
 
 namespace BaconQrCode\Common;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase as TestCase;
 
 class BitMatrixTest extends TestCase
 {

--- a/tests/BaconQrCode/Common/BitUtilsTest.php
+++ b/tests/BaconQrCode/Common/BitUtilsTest.php
@@ -9,7 +9,7 @@
 
 namespace BaconQrCode\Common;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase as TestCase;
 
 class BitUtilsTest extends TestCase
 {

--- a/tests/BaconQrCode/Common/ErrorCorrectionLevelTest.php
+++ b/tests/BaconQrCode/Common/ErrorCorrectionLevelTest.php
@@ -9,7 +9,7 @@
 
 namespace BaconQrCode\Common;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase as TestCase;
 
 class ErrorCorrectionLevelTest extends TestCase
 {
@@ -29,12 +29,12 @@ class ErrorCorrectionLevelTest extends TestCase
         $this->assertEquals(0x3, ErrorCorrectionLevel::Q);
     }
 
+    /**
+     * @expectedException BaconQrCode\Exception\UnexpectedValueException
+     * @expectedExceptionMessage Value not a const in enum BaconQrCode\Common\ErrorCorrectionLevel
+     */
     public function testInvalidErrorCorrectionLevelThrowsException()
     {
-        $this->setExpectedException(
-            'BaconQrCode\Exception\UnexpectedValueException',
-            'Value not a const in enum BaconQrCode\Common\ErrorCorrectionLevel'
-        );
         new ErrorCorrectionLevel(4);
     }
 }

--- a/tests/BaconQrCode/Common/FormatInformationTest.php
+++ b/tests/BaconQrCode/Common/FormatInformationTest.php
@@ -9,7 +9,7 @@
 
 namespace BaconQrCode\Common;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase as TestCase;
 
 class FormatInformationTest extends TestCase
 {

--- a/tests/BaconQrCode/Common/ModeTest.php
+++ b/tests/BaconQrCode/Common/ModeTest.php
@@ -9,7 +9,7 @@
 
 namespace BaconQrCode\Common;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase as TestCase;
 
 class ModeTest extends TestCase
 {
@@ -31,12 +31,12 @@ class ModeTest extends TestCase
         $this->assertEquals(0x8, Mode::KANJI);
     }
 
+    /**
+     * @expectedException BaconQrCode\Exception\UnexpectedValueException
+     * @expectedExceptionMessage Value not a const in enum BaconQrCode\Common\Mode
+     */
     public function testInvalidModeThrowsException()
     {
-        $this->setExpectedException(
-            'BaconQrCode\Exception\UnexpectedValueException',
-            'Value not a const in enum BaconQrCode\Common\Mode'
-        );
         new Mode(10);
     }
 }

--- a/tests/BaconQrCode/Common/ReedSolomonCodecTest.php
+++ b/tests/BaconQrCode/Common/ReedSolomonCodecTest.php
@@ -9,7 +9,7 @@
 
 namespace BaconQrCode\Common;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase as TestCase;
 use SplFixedArray;
 
 class ReedSolomonTest extends TestCase

--- a/tests/BaconQrCode/Common/VersionTest.php
+++ b/tests/BaconQrCode/Common/VersionTest.php
@@ -9,7 +9,7 @@
 
 namespace BaconQrCode\Common;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase as TestCase;
 
 class VersionTest extends TestCase
 {

--- a/tests/BaconQrCode/Encoder/EncoderTest.php
+++ b/tests/BaconQrCode/Encoder/EncoderTest.php
@@ -13,7 +13,7 @@ use BaconQrCode\Common\BitArray;
 use BaconQrCode\Common\ErrorCorrectionLevel;
 use BaconQrCode\Common\Mode;
 use BaconQrCode\Common\Version;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase as TestCase;
 use ReflectionClass;
 use ReflectionMethod;
 use SplFixedArray;
@@ -212,6 +212,10 @@ class EncoderTest extends TestCase
         $this->assertEquals(' ..X..... ....', $bits->__toString());
     }
 
+    /**
+     * @expectedException BaconQrCode\Exception\WriterException
+     * @expectedExceptionMessage Invalid alphanumeric code
+     */
     public function testAppendBytes()
     {
         // Should use appendNumericBytes.
@@ -262,11 +266,6 @@ class EncoderTest extends TestCase
         );
         $this->assertEquals(' .XX.XX.. XXXXX', $bits->__toString());
 
-        // Lower letters such as 'a' cannot be encoded in alphanumeric mode.
-        $this->setExpectedException(
-            'BaconQrCode\Exception\WriterException',
-            'Invalid alphanumeric code'
-        );
         $this->methods['appendBytes']->invoke(
             null,
             "a",
@@ -396,6 +395,10 @@ class EncoderTest extends TestCase
         $this->assertEquals('', $bits->__toString());
     }
 
+    /**
+     * @expectedException BaconQrCode\Exception\WriterException
+     * @expectedExceptionMessage Invalid alphanumeric code
+     */
     public function testAppendAlphanumericBytes()
     {
         $bits = new BitArray();
@@ -416,7 +419,6 @@ class EncoderTest extends TestCase
         $this->assertEquals('', $bits->__toString());
 
         // Invalid data
-        $this->setExpectedException('BaconQrCode\Exception\WriterException', 'Invalid alphanumeric code');
         $bits = new BitArray();
         $this->methods['appendAlphanumericBytes']->invoke(null, 'abc', $bits);
     }

--- a/tests/BaconQrCode/Encoder/MaskUtilTest.php
+++ b/tests/BaconQrCode/Encoder/MaskUtilTest.php
@@ -9,7 +9,7 @@
 
 namespace BaconQrCode\Encoder;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase as TestCase;
 
 class MaskUtilTest extends TestCase
 {

--- a/tests/BaconQrCode/Encoder/MatrixUtilTest.php
+++ b/tests/BaconQrCode/Encoder/MatrixUtilTest.php
@@ -12,7 +12,7 @@ namespace BaconQrCode\Encoder;
 use BaconQrCode\Common\BitArray;
 use BaconQrCode\Common\ErrorCorrectionLevel;
 use BaconQrCode\Common\Version;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase as TestCase;
 use ReflectionClass;
 use ReflectionMethod;
 

--- a/tests/BaconQrCode/Renderer/Text/HtmlTest.php
+++ b/tests/BaconQrCode/Renderer/Text/HtmlTest.php
@@ -12,7 +12,7 @@ namespace BaconQrCode\Encoder;
 use BaconQrCode\Common\ErrorCorrectionLevel;
 use BaconQrCode\Renderer\Text\Html;
 use BaconQrCode\Writer;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase as TestCase;
 
 class HtmlTest extends TestCase
 {

--- a/tests/BaconQrCode/Renderer/Text/TextTest.php
+++ b/tests/BaconQrCode/Renderer/Text/TextTest.php
@@ -12,7 +12,7 @@ namespace BaconQrCode\Encoder;
 use BaconQrCode\Common\ErrorCorrectionLevel;
 use BaconQrCode\Renderer\Text\Plain;
 use BaconQrCode\Writer;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase as TestCase;
 
 class PlainTest extends TestCase
 {


### PR DESCRIPTION
So latest version, compatible with latest  PHP version will be used when needed
* 4.8 with PHP < 5.6
* 5.7 with PHP 5.6
* 6.2 with PHP > 7