### PR TITLE
Included 'return', for ease of testing on QRCode generation.

### DIFF
--- a/src/BaconQrCode/Writer.php
+++ b/src/BaconQrCode/Writer.php
@@ -100,6 +100,6 @@ class Writer
         $encoding = Encoder::DEFAULT_BYTE_MODE_ECODING,
         $ecLevel = ErrorCorrectionLevel::L
     ) {
-        file_put_contents($filename, $this->writeString($content, $encoding, $ecLevel));
+        return file_put_contents($filename, $this->writeString($content, $encoding, $ecLevel));
     }
 }


### PR DESCRIPTION
With the addition of the 'return' statement, it facilitates the creation of unit tests for QR Code generator.
Allowing you to test whether the file was generated or not.