### PR TITLE
Add better SVG renderer

### DIFF
--- a/autoload_classmap.php
+++ b/autoload_classmap.php
@@ -36,6 +36,7 @@ return array(
     'BaconQrCode\Renderer\Image\Png'                          => __DIR__ . '/src/BaconQrCode/Renderer/Image/Png.php',
     'BaconQrCode\Renderer\Image\RendererInterface'            => __DIR__ . '/src/BaconQrCode/Renderer/Image/RendererInterface.php',
     'BaconQrCode\Renderer\Image\Svg'                          => __DIR__ . '/src/BaconQrCode/Renderer/Image/Svg.php',
+    'BaconQrCode\Renderer\Image\SvgPath'                      => __DIR__ . '/src/BaconQrCode/Renderer/Image/SvgPath.php',
     'BaconQrCode\Renderer\RendererInterface'                  => __DIR__ . '/src/BaconQrCode/Renderer/RendererInterface.php',
     'BaconQrCode\Renderer\Text\Plain'                         => __DIR__ . '/src/BaconQrCode/Renderer/Text/Plain.php',
     'BaconQrCode\Renderer\Text\Html'                          => __DIR__ . '/src/BaconQrCode/Renderer/Text/Html.php',

--- a/src/BaconQrCode/Renderer/Image/SvgPath.php
+++ b/src/BaconQrCode/Renderer/Image/SvgPath.php
@@ -1,0 +1,161 @@
+<?php
+/**
+ * BaconQrCode
+ *
+ * @link      http://github.com/Bacon/BaconQrCode For the canonical source repository
+ * @copyright 2013 Ben 'DASPRiD' Scholzen
+ * @license   http://opensource.org/licenses/BSD-2-Clause Simplified BSD License
+ */
+
+namespace BaconQrCode\Renderer\Image;
+
+use BaconQrCode\Exception;
+use BaconQrCode\Renderer\Color\ColorInterface;
+use SimpleXMLElement;
+
+/**
+ * SVG "Path" backend.
+ */
+class SvgPath extends AbstractRenderer
+{
+    /**
+     * SVG resource.
+     *
+     * @var SimpleXMLElement
+     */
+    protected $svg;
+
+    /**
+     * Colors used for drawing.
+     *
+     * @var array
+     */
+    protected $colors = array();
+
+    /**
+     * SVG path commands used for drawing.
+     *
+     * Two-dimensional array where first dimension is color
+     * and second dimension contains ordered list of SVG path commands.
+     *
+     * @var array
+     */
+    protected $pathCommands = array();
+
+    /**
+     * init(): defined by RendererInterface.
+     *
+     * @see    ImageRendererInterface::init()
+     * @return void
+     */
+    public function init()
+    {
+        $this->svg = new SimpleXMLElement(
+            '<?xml version="1.0" encoding="UTF-8"?>'
+            . '<svg xmlns="http://www.w3.org/2000/svg"/>'
+        );
+        $this->svg->addAttribute('version', '1.1');
+        $this->svg->addAttribute('width', $this->finalWidth . 'px');
+        $this->svg->addAttribute('height', $this->finalHeight . 'px');
+        $this->svg->addAttribute('viewBox', '0 0 ' . $this->finalWidth . ' ' . $this->finalHeight);
+    }
+
+    /**
+     * addColor(): defined by RendererInterface.
+     *
+     * @see    ImageRendererInterface::addColor()
+     * @param  string         $id
+     * @param  ColorInterface $color
+     * @return void
+     * @throws Exception\InvalidArgumentException
+     */
+    public function addColor($id, ColorInterface $color)
+    {
+        $this->colors[$id] = (string) $color->toRgb();
+    }
+
+    /**
+     * drawBackground(): defined by RendererInterface.
+     *
+     * @see    ImageRendererInterface::drawBackground()
+     * @param  string $colorId
+     * @return void
+     */
+    public function drawBackground($colorId)
+    {
+        $background = $this->drawPath(
+            array(
+                'M 0 0',
+                sprintf('H %s', $this->finalWidth),
+                sprintf('V %s', $this->finalHeight),
+                'H 0',
+                'V 0',
+            ),
+            $this->colors[$colorId]
+        );
+
+        $background->addAttribute('id', 'bg');
+    }
+
+    /**
+     * drawBlock(): defined by RendererInterface.
+     *
+     * @see    ImageRendererInterface::drawBlock()
+     * @param  integer $x
+     * @param  integer $y
+     * @param  string  $colorId
+     * @return void
+     */
+    public function drawBlock($x, $y, $colorId)
+    {
+        if (!isset($this->pathCommands[$colorId])) {
+            $this->pathCommands[$colorId] = array();
+        }
+
+        $this->pathCommands[$colorId][] = sprintf('M %s %s', $x, $y);
+        $this->pathCommands[$colorId][] = sprintf('h%s', $this->blockSize);
+        $this->pathCommands[$colorId][] = sprintf('v%s', $this->blockSize);
+        $this->pathCommands[$colorId][] = sprintf('h-%s', $this->blockSize);
+        $this->pathCommands[$colorId][] = sprintf('v-%s', $this->blockSize);
+    }
+
+    /**
+     * getByteStream(): defined by RendererInterface.
+     *
+     * @see    ImageRendererInterface::getByteStream()
+     * @return string
+     */
+    public function getByteStream()
+    {
+        $this->renderPaths();
+
+        return $this->svg->asXML();
+    }
+
+    /**
+     * Renders all "prepared" paths into the SVG.
+     */
+    protected function renderPaths()
+    {
+        foreach ($this->pathCommands as $colorId => $commands) {
+            $this->drawPath($commands, $this->colors[$colorId]);
+        }
+    }
+
+    /**
+     * Draws a path into the SVG.
+     *
+     * @param array $commands
+     * @param string $fillColor
+     *
+     * @return SimpleXMLElement
+     */
+    protected function drawPath(array $commands, $fillColor)
+    {
+        $path = $this->svg->addChild('path');
+        $path->addAttribute('fill', '#' . $fillColor);
+        $path->addAttribute('d', implode(' ', $commands));
+
+        return $path;
+    }
+}


### PR DESCRIPTION
There is a rendering, aliasing-related [bug](https://stackoverflow.com/a/36862330/1306158) in SVG that causes blocks that are next to each other to render with a thin white line between them on some resolutions / "zoom levels". It looks like this (see the tiny lines?): 
![svg-artifact](https://user-images.githubusercontent.com/781546/31773238-68bef0c6-b4e2-11e7-8440-26b24a8f7112.png)

I have solved this issue by writing a new SVG renderer based on SVG's path element. A nice side effect is that this about halves the resulting SVG size, it consumes less memory and works faster (because we just use an array and single SimpleXMLElement instead of one for every block.

It also supports multiple colors if that was desired, though I assume that the aliasing bug would then still be seen between the different colors/paths but it shouldn't be as noticeable.

Also note that the SVG could still be optimized for size further in at least two ways:
- One could write an algorithm to "join" blocks that share sides and draw only the outline. This would immensely lower the output size (probably by another 50% or so), but it'd increase computation time. This could be a great trade-off but it should be optional and I personally don't know how to write such algorithm.
- We could draw the path with block size of 1 and only scale it so that it matches the target dimensions. This would make the result smaller for any SVGs with block size bigger than 9. Possibly worth it, I didn't have time to implement it.

Example writer output for `size: 252`:
```svg
<?xml version="1.0" encoding="UTF-8"?>
<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="252px" height="252px" viewBox="0 0 252 252">
    <path fill="#ffffff" d="M 0 0 H 252 V 252 H 0 V 0" id="bg" />
    <path fill="#000000" d="M 0 0 h12 v12 h-12 v-12 M 12 0 h12 v12 h-12 v-12 M 24 0 h12 v12 h-12 v-12 M 36 0 h12 v12 h-12 v-12 M 48 0 h12 v12 h-12 v-12 M 60 0 h12 v12 h-12 v-12 M 72 0 h12 v12 h-12 v-12 M 96 0 h12 v12 h-12 v-12 M 132 0 h12 v12 h-12 v-12 M 168 0 h12 v12 h-12 v-12 M 180 0 h12 v12 h-12 v-12 M 192 0 h12 v12 h-12 v-12 M 204 0 h12 v12 h-12 v-12 M 216 0 h12 v12 h-12 v-12 M 228 0 h12 v12 h-12 v-12 M 240 0 h12 v12 h-12 v-12 M 0 12 h12 v12 h-12 v-12 M 72 12 h12 v12 h-12 v-12 M 120 12 h12 v12 h-12 v-12 M 132 12 h12 v12 h-12 v-12 M 168 12 h12 v12 h-12 v-12 M 240 12 h12 v12 h-12 v-12 M 0 24 h12 v12 h-12 v-12 M 24 24 h12 v12 h-12 v-12 M 36 24 h12 v12 h-12 v-12 M 48 24 h12 v12 h-12 v-12 M 72 24 h12 v12 h-12 v-12 M 96 24 h12 v12 h-12 v-12 M 108 24 h12 v12 h-12 v-12 M 132 24 h12 v12 h-12 v-12 M 168 24 h12 v12 h-12 v-12 M 192 24 h12 v12 h-12 v-12 M 204 24 h12 v12 h-12 v-12 M 216 24 h12 v12 h-12 v-12 M 240 24 h12 v12 h-12 v-12 M 0 36 h12 v12 h-12 v-12 M 24 36 h12 v12 h-12 v-12 M 36 36 h12 v12 h-12 v-12 M 48 36 h12 v12 h-12 v-12 M 72 36 h12 v12 h-12 v-12 M 96 36 h12 v12 h-12 v-12 M 108 36 h12 v12 h-12 v-12 M 144 36 h12 v12 h-12 v-12 M 168 36 h12 v12 h-12 v-12 M 192 36 h12 v12 h-12 v-12 M 204 36 h12 v12 h-12 v-12 M 216 36 h12 v12 h-12 v-12 M 240 36 h12 v12 h-12 v-12 M 0 48 h12 v12 h-12 v-12 M 24 48 h12 v12 h-12 v-12 M 36 48 h12 v12 h-12 v-12 M 48 48 h12 v12 h-12 v-12 M 72 48 h12 v12 h-12 v-12 M 108 48 h12 v12 h-12 v-12 M 120 48 h12 v12 h-12 v-12 M 144 48 h12 v12 h-12 v-12 M 168 48 h12 v12 h-12 v-12 M 192 48 h12 v12 h-12 v-12 M 204 48 h12 v12 h-12 v-12 M 216 48 h12 v12 h-12 v-12 M 240 48 h12 v12 h-12 v-12 M 0 60 h12 v12 h-12 v-12 M 72 60 h12 v12 h-12 v-12 M 96 60 h12 v12 h-12 v-12 M 144 60 h12 v12 h-12 v-12 M 168 60 h12 v12 h-12 v-12 M 240 60 h12 v12 h-12 v-12 M 0 72 h12 v12 h-12 v-12 M 12 72 h12 v12 h-12 v-12 M 24 72 h12 v12 h-12 v-12 M 36 72 h12 v12 h-12 v-12 M 48 72 h12 v12 h-12 v-12 M 60 72 h12 v12 h-12 v-12 M 72 72 h12 v12 h-12 v-12 M 96 72 h12 v12 h-12 v-12 M 120 72 h12 v12 h-12 v-12 M 144 72 h12 v12 h-12 v-12 M 168 72 h12 v12 h-12 v-12 M 180 72 h12 v12 h-12 v-12 M 192 72 h12 v12 h-12 v-12 M 204 72 h12 v12 h-12 v-12 M 216 72 h12 v12 h-12 v-12 M 228 72 h12 v12 h-12 v-12 M 240 72 h12 v12 h-12 v-12 M 96 84 h12 v12 h-12 v-12 M 108 84 h12 v12 h-12 v-12 M 144 84 h12 v12 h-12 v-12 M 12 96 h12 v12 h-12 v-12 M 36 96 h12 v12 h-12 v-12 M 60 96 h12 v12 h-12 v-12 M 72 96 h12 v12 h-12 v-12 M 84 96 h12 v12 h-12 v-12 M 96 96 h12 v12 h-12 v-12 M 108 96 h12 v12 h-12 v-12 M 120 96 h12 v12 h-12 v-12 M 132 96 h12 v12 h-12 v-12 M 144 96 h12 v12 h-12 v-12 M 156 96 h12 v12 h-12 v-12 M 168 96 h12 v12 h-12 v-12 M 180 96 h12 v12 h-12 v-12 M 204 96 h12 v12 h-12 v-12 M 216 96 h12 v12 h-12 v-12 M 240 96 h12 v12 h-12 v-12 M 0 108 h12 v12 h-12 v-12 M 48 108 h12 v12 h-12 v-12 M 60 108 h12 v12 h-12 v-12 M 84 108 h12 v12 h-12 v-12 M 132 108 h12 v12 h-12 v-12 M 156 108 h12 v12 h-12 v-12 M 192 108 h12 v12 h-12 v-12 M 204 108 h12 v12 h-12 v-12 M 240 108 h12 v12 h-12 v-12 M 0 120 h12 v12 h-12 v-12 M 12 120 h12 v12 h-12 v-12 M 48 120 h12 v12 h-12 v-12 M 72 120 h12 v12 h-12 v-12 M 144 120 h12 v12 h-12 v-12 M 156 120 h12 v12 h-12 v-12 M 180 120 h12 v12 h-12 v-12 M 216 120 h12 v12 h-12 v-12 M 36 132 h12 v12 h-12 v-12 M 120 132 h12 v12 h-12 v-12 M 144 132 h12 v12 h-12 v-12 M 156 132 h12 v12 h-12 v-12 M 180 132 h12 v12 h-12 v-12 M 192 132 h12 v12 h-12 v-12 M 240 132 h12 v12 h-12 v-12 M 24 144 h12 v12 h-12 v-12 M 60 144 h12 v12 h-12 v-12 M 72 144 h12 v12 h-12 v-12 M 96 144 h12 v12 h-12 v-12 M 120 144 h12 v12 h-12 v-12 M 144 144 h12 v12 h-12 v-12 M 156 144 h12 v12 h-12 v-12 M 180 144 h12 v12 h-12 v-12 M 216 144 h12 v12 h-12 v-12 M 228 144 h12 v12 h-12 v-12 M 96 156 h12 v12 h-12 v-12 M 120 156 h12 v12 h-12 v-12 M 132 156 h12 v12 h-12 v-12 M 156 156 h12 v12 h-12 v-12 M 168 156 h12 v12 h-12 v-12 M 204 156 h12 v12 h-12 v-12 M 228 156 h12 v12 h-12 v-12 M 240 156 h12 v12 h-12 v-12 M 0 168 h12 v12 h-12 v-12 M 12 168 h12 v12 h-12 v-12 M 24 168 h12 v12 h-12 v-12 M 36 168 h12 v12 h-12 v-12 M 48 168 h12 v12 h-12 v-12 M 60 168 h12 v12 h-12 v-12 M 72 168 h12 v12 h-12 v-12 M 96 168 h12 v12 h-12 v-12 M 108 168 h12 v12 h-12 v-12 M 120 168 h12 v12 h-12 v-12 M 144 168 h12 v12 h-12 v-12 M 168 168 h12 v12 h-12 v-12 M 180 168 h12 v12 h-12 v-12 M 204 168 h12 v12 h-12 v-12 M 216 168 h12 v12 h-12 v-12 M 0 180 h12 v12 h-12 v-12 M 72 180 h12 v12 h-12 v-12 M 96 180 h12 v12 h-12 v-12 M 120 180 h12 v12 h-12 v-12 M 132 180 h12 v12 h-12 v-12 M 144 180 h12 v12 h-12 v-12 M 156 180 h12 v12 h-12 v-12 M 192 180 h12 v12 h-12 v-12 M 204 180 h12 v12 h-12 v-12 M 228 180 h12 v12 h-12 v-12 M 240 180 h12 v12 h-12 v-12 M 0 192 h12 v12 h-12 v-12 M 24 192 h12 v12 h-12 v-12 M 36 192 h12 v12 h-12 v-12 M 48 192 h12 v12 h-12 v-12 M 72 192 h12 v12 h-12 v-12 M 120 192 h12 v12 h-12 v-12 M 132 192 h12 v12 h-12 v-12 M 144 192 h12 v12 h-12 v-12 M 168 192 h12 v12 h-12 v-12 M 192 192 h12 v12 h-12 v-12 M 216 192 h12 v12 h-12 v-12 M 240 192 h12 v12 h-12 v-12 M 0 204 h12 v12 h-12 v-12 M 24 204 h12 v12 h-12 v-12 M 36 204 h12 v12 h-12 v-12 M 48 204 h12 v12 h-12 v-12 M 72 204 h12 v12 h-12 v-12 M 96 204 h12 v12 h-12 v-12 M 108 204 h12 v12 h-12 v-12 M 168 204 h12 v12 h-12 v-12 M 180 204 h12 v12 h-12 v-12 M 192 204 h12 v12 h-12 v-12 M 228 204 h12 v12 h-12 v-12 M 240 204 h12 v12 h-12 v-12 M 0 216 h12 v12 h-12 v-12 M 24 216 h12 v12 h-12 v-12 M 36 216 h12 v12 h-12 v-12 M 48 216 h12 v12 h-12 v-12 M 72 216 h12 v12 h-12 v-12 M 108 216 h12 v12 h-12 v-12 M 144 216 h12 v12 h-12 v-12 M 192 216 h12 v12 h-12 v-12 M 216 216 h12 v12 h-12 v-12 M 240 216 h12 v12 h-12 v-12 M 0 228 h12 v12 h-12 v-12 M 72 228 h12 v12 h-12 v-12 M 96 228 h12 v12 h-12 v-12 M 132 228 h12 v12 h-12 v-12 M 168 228 h12 v12 h-12 v-12 M 192 228 h12 v12 h-12 v-12 M 204 228 h12 v12 h-12 v-12 M 228 228 h12 v12 h-12 v-12 M 0 240 h12 v12 h-12 v-12 M 12 240 h12 v12 h-12 v-12 M 24 240 h12 v12 h-12 v-12 M 36 240 h12 v12 h-12 v-12 M 48 240 h12 v12 h-12 v-12 M 60 240 h12 v12 h-12 v-12 M 72 240 h12 v12 h-12 v-12 M 120 240 h12 v12 h-12 v-12 M 132 240 h12 v12 h-12 v-12 M 144 240 h12 v12 h-12 v-12 M 192 240 h12 v12 h-12 v-12 M 204 240 h12 v12 h-12 v-12 M 216 240 h12 v12 h-12 v-12" />
</svg>
```

![991000000004703924702090 svg](https://user-images.githubusercontent.com/781546/31774978-909efaa0-b4e7-11e7-9338-afe5af15b09b.png)

Notice there are no lines between the blocks.