### PR TITLE
Php32 infinite loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,9 @@ $renderer->setWidth(256);
 $writer = new \BaconQrCode\Writer($renderer);
 $writer->writeFile('Hello World!', 'qrcode.png');
 ```
+
+
+Run tests
+---------
+`vendor\bin\phpunit --bootstrap tests/bootstrap.php --configuration tests/phpunit.xml tests` on Windows
+`vendor/bin/phpunit --bootstrap tests/bootstrap.php --configuration tests/phpunit.xml tests` on Linux

--- a/src/BaconQrCode/Encoder/MatrixUtil.php
+++ b/src/BaconQrCode/Encoder/MatrixUtil.php
@@ -316,6 +316,11 @@ class MatrixUtil
         while ($value !== 0) {
             $value >>= 1;
             $numDigits++;
+            // If 32 bit php is used, $value could be -1 on integer overflow.
+            // And this causes infinite loop on test run.
+            if ($value === -1) {
+                break;
+            }
         }
 
         return $numDigits;


### PR DESCRIPTION
PHP 32 bit hangs on infinite loop while tests are run. This fixes the problem. 
Still we have 2 tests fail, that could be reworked to support 32 bit.
BitArrayTest::testGetArray - Failed asserting that -2147483648 matches expected 2147483648.
MatrixUtilTest::testFindMsbSet - Failed asserting that 30 matches expected 32.