### PR TITLE
Fix round decimals with some non English locale

### DIFF
--- a/src/Renderer/Image/EpsImageBackEnd.php
+++ b/src/Renderer/Image/EpsImageBackEnd.php
@@ -75,7 +75,7 @@ final class EpsImageBackEnd implements ImageBackEndInterface
             throw new RuntimeException('No image has been started');
         }
 
-        $this->eps .= sprintf("%1\$s %1\$s s\n", round($size, self::PRECISION));
+        $this->eps .= sprintf("%1\$s %1\$s s\n", number_format($size, self::PRECISION));
     }
 
     public function translate(float $x, float $y) : void
@@ -84,7 +84,7 @@ final class EpsImageBackEnd implements ImageBackEndInterface
             throw new RuntimeException('No image has been started');
         }
 
-        $this->eps .= sprintf("%s %s t\n", round($x, self::PRECISION), round($y, self::PRECISION));
+        $this->eps .= sprintf("%s %s t\n", number_format($x, self::PRECISION), number_format($y, self::PRECISION));
     }
 
     public function rotate(int $degrees) : void
@@ -174,14 +174,14 @@ final class EpsImageBackEnd implements ImageBackEndInterface
         foreach ($ops as $op) {
             switch (true) {
                 case $op instanceof Move:
-                    $fromX = $toX = round($op->getX(), self::PRECISION);
-                    $fromY = $toY = round($op->getY(), self::PRECISION);
+                    $fromX = $toX = number_format($op->getX(), self::PRECISION);
+                    $fromY = $toY = number_format($op->getY(), self::PRECISION);
                     $pathData[] = sprintf('%s %s m', $toX, $toY);
                     break;
 
                 case $op instanceof Line:
-                    $fromX = $toX = round($op->getX(), self::PRECISION);
-                    $fromY = $toY = round($op->getY(), self::PRECISION);
+                    $fromX = $toX = number_format($op->getX(), self::PRECISION);
+                    $fromY = $toY = number_format($op->getY(), self::PRECISION);
                     $pathData[] = sprintf('%s %s l', $toX, $toY);
                     break;
 
@@ -190,12 +190,12 @@ final class EpsImageBackEnd implements ImageBackEndInterface
                     break;
 
                 case $op instanceof Curve:
-                    $x1 = round($op->getX1(), self::PRECISION);
-                    $y1 = round($op->getY1(), self::PRECISION);
-                    $x2 = round($op->getX2(), self::PRECISION);
-                    $y2 = round($op->getY2(), self::PRECISION);
-                    $fromX = $x3 = round($op->getX3(), self::PRECISION);
-                    $fromY = $y3 = round($op->getY3(), self::PRECISION);
+                    $x1 = number_format($op->getX1(), self::PRECISION);
+                    $y1 = number_format($op->getY1(), self::PRECISION);
+                    $x2 = number_format($op->getX2(), self::PRECISION);
+                    $y2 = number_format($op->getY2(), self::PRECISION);
+                    $fromX = $x3 = number_format($op->getX3(), self::PRECISION);
+                    $fromY = $y3 = number_format($op->getY3(), self::PRECISION);
                     $pathData[] = sprintf('%s %s %s %s %s %s c', $x1, $y1, $x2, $y2, $x3, $y3);
                     break;
 
@@ -272,40 +272,40 @@ final class EpsImageBackEnd implements ImageBackEndInterface
             case GradientType::HORIZONTAL():
                 $this->eps .= sprintf(
                     " /Coords [ %s %s %s %s ]\n",
-                    round($x, self::PRECISION),
-                    round($y, self::PRECISION),
-                    round($x + $width, self::PRECISION),
-                    round($y, self::PRECISION)
+                    number_format($x, self::PRECISION),
+                    number_format($y, self::PRECISION),
+                    number_format($x + $width, self::PRECISION),
+                    number_format($y, self::PRECISION)
                 );
                 break;
 
             case GradientType::VERTICAL():
                 $this->eps .= sprintf(
                     " /Coords [ %s %s %s %s ]\n",
-                    round($x, self::PRECISION),
-                    round($y, self::PRECISION),
-                    round($x, self::PRECISION),
-                    round($y + $height, self::PRECISION)
+                    number_format($x, self::PRECISION),
+                    number_format($y, self::PRECISION),
+                    number_format($x, self::PRECISION),
+                    number_format($y + $height, self::PRECISION)
                 );
                 break;
 
             case GradientType::DIAGONAL():
                 $this->eps .= sprintf(
                     " /Coords [ %s %s %s %s ]\n",
-                    round($x, self::PRECISION),
-                    round($y, self::PRECISION),
-                    round($x + $width, self::PRECISION),
-                    round($y + $height, self::PRECISION)
+                    number_format($x, self::PRECISION),
+                    number_format($y, self::PRECISION),
+                    number_format($x + $width, self::PRECISION),
+                    number_format($y + $height, self::PRECISION)
                 );
                 break;
 
             case GradientType::INVERSE_DIAGONAL():
                 $this->eps .= sprintf(
                     " /Coords [ %s %s %s %s ]\n",
-                    round($x, self::PRECISION),
-                    round($y + $height, self::PRECISION),
-                    round($x + $width, self::PRECISION),
-                    round($y, self::PRECISION)
+                    number_format($x, self::PRECISION),
+                    number_format($y + $height, self::PRECISION),
+                    number_format($x + $width, self::PRECISION),
+                    number_format($y, self::PRECISION)
                 );
                 break;
 
@@ -315,11 +315,11 @@ final class EpsImageBackEnd implements ImageBackEndInterface
 
                 $this->eps .= sprintf(
                     " /Coords [ %s %s 0 %s %s %s ]\n",
-                    round($centerX, self::PRECISION),
-                    round($centerY, self::PRECISION),
-                    round($centerX, self::PRECISION),
-                    round($centerY, self::PRECISION),
-                    round(max($width, $height) / 2, self::PRECISION)
+                    number_format($centerX, self::PRECISION),
+                    number_format($centerY, self::PRECISION),
+                    number_format($centerX, self::PRECISION),
+                    number_format($centerY, self::PRECISION),
+                    number_format(max($width, $height) / 2, self::PRECISION)
                 );
                 break;
         }

--- a/src/Renderer/Image/SvgImageBackEnd.php
+++ b/src/Renderer/Image/SvgImageBackEnd.php
@@ -97,7 +97,7 @@ final class SvgImageBackEnd implements ImageBackEndInterface
         $this->xmlWriter->startElement('g');
         $this->xmlWriter->writeAttribute(
             'transform',
-            sprintf('scale(%s)', round($size, self::PRECISION))
+            sprintf('scale(%s)', number_format($size, self::PRECISION))
         );
         ++$this->stack[$this->currentStack];
     }
@@ -111,7 +111,7 @@ final class SvgImageBackEnd implements ImageBackEndInterface
         $this->xmlWriter->startElement('g');
         $this->xmlWriter->writeAttribute(
             'transform',
-            sprintf('translate(%s,%s)', round($x, self::PRECISION), round($y, self::PRECISION))
+            sprintf('translate(%s,%s)', number_format($x, self::PRECISION), number_format($y, self::PRECISION))
         );
         ++$this->stack[$this->currentStack];
     }
@@ -223,41 +223,41 @@ final class SvgImageBackEnd implements ImageBackEndInterface
                 case $op instanceof Move:
                     $pathData[] = sprintf(
                         'M%s %s',
-                        round($op->getX(), self::PRECISION),
-                        round($op->getY(), self::PRECISION)
+                        number_format($op->getX(), self::PRECISION),
+                        number_format($op->getY(), self::PRECISION)
                     );
                     break;
 
                 case $op instanceof Line:
                     $pathData[] = sprintf(
                         'L%s %s',
-                        round($op->getX(), self::PRECISION),
-                        round($op->getY(), self::PRECISION)
+                        number_format($op->getX(), self::PRECISION),
+                        number_format($op->getY(), self::PRECISION)
                     );
                     break;
 
                 case $op instanceof EllipticArc:
                     $pathData[] = sprintf(
                         'A%s %s %s %u %u %s %s',
-                        round($op->getXRadius(), self::PRECISION),
-                        round($op->getYRadius(), self::PRECISION),
-                        round($op->getXAxisAngle(), self::PRECISION),
+                        number_format($op->getXRadius(), self::PRECISION),
+                        number_format($op->getYRadius(), self::PRECISION),
+                        number_format($op->getXAxisAngle(), self::PRECISION),
                         $op->isLargeArc(),
                         $op->isSweep(),
-                        round($op->getX(), self::PRECISION),
-                        round($op->getY(), self::PRECISION)
+                        number_format($op->getX(), self::PRECISION),
+                        number_format($op->getY(), self::PRECISION)
                     );
                     break;
 
                 case $op instanceof Curve:
                     $pathData[] = sprintf(
                         'C%s %s %s %s %s %s',
-                        round($op->getX1(), self::PRECISION),
-                        round($op->getY1(), self::PRECISION),
-                        round($op->getX2(), self::PRECISION),
-                        round($op->getY2(), self::PRECISION),
-                        round($op->getX3(), self::PRECISION),
-                        round($op->getY3(), self::PRECISION)
+                        number_format($op->getX1(), self::PRECISION),
+                        number_format($op->getY1(), self::PRECISION),
+                        number_format($op->getX2(), self::PRECISION),
+                        number_format($op->getY2(), self::PRECISION),
+                        number_format($op->getX3(), self::PRECISION),
+                        number_format($op->getY3(), self::PRECISION)
                     );
                     break;
 
@@ -292,37 +292,37 @@ final class SvgImageBackEnd implements ImageBackEndInterface
 
         switch ($gradient->getType()) {
             case GradientType::HORIZONTAL():
-                $this->xmlWriter->writeAttribute('x1', (string) round($x, self::PRECISION));
-                $this->xmlWriter->writeAttribute('y1', (string) round($y, self::PRECISION));
-                $this->xmlWriter->writeAttribute('x2', (string) round($x + $width, self::PRECISION));
-                $this->xmlWriter->writeAttribute('y2', (string) round($y, self::PRECISION));
+                $this->xmlWriter->writeAttribute('x1', number_format($x, self::PRECISION));
+                $this->xmlWriter->writeAttribute('y1', number_format($y, self::PRECISION));
+                $this->xmlWriter->writeAttribute('x2', number_format($x + $width, self::PRECISION));
+                $this->xmlWriter->writeAttribute('y2', number_format($y, self::PRECISION));
                 break;
 
             case GradientType::VERTICAL():
-                $this->xmlWriter->writeAttribute('x1', (string) round($x, self::PRECISION));
-                $this->xmlWriter->writeAttribute('y1', (string) round($y, self::PRECISION));
-                $this->xmlWriter->writeAttribute('x2', (string) round($x, self::PRECISION));
-                $this->xmlWriter->writeAttribute('y2', (string) round($y + $height, self::PRECISION));
+                $this->xmlWriter->writeAttribute('x1', number_format($x, self::PRECISION));
+                $this->xmlWriter->writeAttribute('y1', number_format($y, self::PRECISION));
+                $this->xmlWriter->writeAttribute('x2', number_format($x, self::PRECISION));
+                $this->xmlWriter->writeAttribute('y2', number_format($y + $height, self::PRECISION));
                 break;
 
             case GradientType::DIAGONAL():
-                $this->xmlWriter->writeAttribute('x1', (string) round($x, self::PRECISION));
-                $this->xmlWriter->writeAttribute('y1', (string) round($y, self::PRECISION));
-                $this->xmlWriter->writeAttribute('x2', (string) round($x + $width, self::PRECISION));
-                $this->xmlWriter->writeAttribute('y2', (string) round($y + $height, self::PRECISION));
+                $this->xmlWriter->writeAttribute('x1', number_format($x, self::PRECISION));
+                $this->xmlWriter->writeAttribute('y1', number_format($y, self::PRECISION));
+                $this->xmlWriter->writeAttribute('x2', number_format($x + $width, self::PRECISION));
+                $this->xmlWriter->writeAttribute('y2', number_format($y + $height, self::PRECISION));
                 break;
 
             case GradientType::INVERSE_DIAGONAL():
-                $this->xmlWriter->writeAttribute('x1', (string) round($x, self::PRECISION));
-                $this->xmlWriter->writeAttribute('y1', (string) round($y + $height, self::PRECISION));
-                $this->xmlWriter->writeAttribute('x2', (string) round($x + $width, self::PRECISION));
-                $this->xmlWriter->writeAttribute('y2', (string) round($y, self::PRECISION));
+                $this->xmlWriter->writeAttribute('x1', number_format($x, self::PRECISION));
+                $this->xmlWriter->writeAttribute('y1', number_format($y + $height, self::PRECISION));
+                $this->xmlWriter->writeAttribute('x2', number_format($x + $width, self::PRECISION));
+                $this->xmlWriter->writeAttribute('y2', number_format($y, self::PRECISION));
                 break;
 
             case GradientType::RADIAL():
-                $this->xmlWriter->writeAttribute('cx', (string) round(($x + $width) / 2, self::PRECISION));
-                $this->xmlWriter->writeAttribute('cy', (string) round(($y + $height) / 2, self::PRECISION));
-                $this->xmlWriter->writeAttribute('r', (string) round(max($width, $height) / 2, self::PRECISION));
+                $this->xmlWriter->writeAttribute('cx', number_format(($x + $width) / 2, self::PRECISION));
+                $this->xmlWriter->writeAttribute('cy', number_format(($y + $height) / 2, self::PRECISION));
+                $this->xmlWriter->writeAttribute('r', number_format(max($width, $height) / 2, self::PRECISION));
                 break;
         }
 


### PR DESCRIPTION
Decimals in SVG and EPS use the point notation. But in enviroments with intl module activate, the decimals can be represented with commas. For example when we use Spanish or Frech locale numeric.

I propose you to change round with number_format. This function does round too, uses point to decimal notation and returns a string.