### PR TITLE
New option for Encoder to define a QR code version number

### DIFF
--- a/src/Encoder/Encoder.php
+++ b/src/Encoder/Encoder.php
@@ -47,7 +47,8 @@ final class Encoder
     public static function encode(
         string $content,
         ErrorCorrectionLevel $ecLevel,
-        string $encoding = self::DEFAULT_BYTE_MODE_ECODING
+        string $encoding = self::DEFAULT_BYTE_MODE_ECODING,
+        ?Version $versionNumber = null
     ) : QrCode {
         // Pick an encoding mode appropriate for the content. Note that this
         // will not attempt to use multiple modes / segments even if that were
@@ -83,12 +84,16 @@ final class Encoder
             + $dataBits->getSize();
         $provisionalVersion = self::chooseVersion($provisionalBitsNeeded, $ecLevel);
 
-        // Use that guess to calculate the right version. I am still not sure
-        // this works in 100% of cases.
-        $bitsNeeded = $headerBits->getSize()
-            + $mode->getCharacterCountBits($provisionalVersion)
-            + $dataBits->getSize();
-        $version = self::chooseVersion($bitsNeeded, $ecLevel);
+        if (null !== $versionNumber) {
+            $version = $versionNumber;
+        } else {
+            // Use that guess to calculate the right version. I am still not sure
+            // this works in 100% of cases.
+            $bitsNeeded = $headerBits->getSize()
+                + $mode->getCharacterCountBits($provisionalVersion)
+                + $dataBits->getSize();
+            $version = self::chooseVersion($bitsNeeded, $ecLevel);
+        }
 
         $headerAndDataBits = new BitArray();
         $headerAndDataBits->appendBitArray($headerBits);

--- a/src/Encoder/Encoder.php
+++ b/src/Encoder/Encoder.php
@@ -48,7 +48,7 @@ final class Encoder
         string $content,
         ErrorCorrectionLevel $ecLevel,
         string $encoding = self::DEFAULT_BYTE_MODE_ECODING,
-        ?Version $versionNumber = null
+        ?Version $forcedVersion = null
     ) : QrCode {
         // Pick an encoding mode appropriate for the content. Note that this
         // will not attempt to use multiple modes / segments even if that were
@@ -84,8 +84,9 @@ final class Encoder
             + $dataBits->getSize();
         $provisionalVersion = self::chooseVersion($provisionalBitsNeeded, $ecLevel);
 
-        if (null !== $versionNumber) {
-            $version = $versionNumber;
+        if (null !== $forcedVersion) {
+            // Forced version number 
+            $version = $forcedVersion;
         } else {
             // Use that guess to calculate the right version. I am still not sure
             // this works in 100% of cases.

--- a/src/Encoder/Encoder.php
+++ b/src/Encoder/Encoder.php
@@ -76,18 +76,18 @@ final class Encoder
         $dataBits = new BitArray();
         self::appendBytes($content, $mode, $dataBits, $encoding);
 
-        // Hard part: need to know version to know how many bits length takes.
-        // But need to know how many bits it takes to know version. First we
-        // take a guess at version by assuming version will be the minimum, 1:
-        $provisionalBitsNeeded = $headerBits->getSize()
-            + $mode->getCharacterCountBits(Version::getVersionForNumber(1))
-            + $dataBits->getSize();
-        $provisionalVersion = self::chooseVersion($provisionalBitsNeeded, $ecLevel);
-
         if (null !== $forcedVersion) {
             // Forced version number 
             $version = $forcedVersion;
         } else {
+            // Hard part: need to know version to know how many bits length takes.
+            // But need to know how many bits it takes to know version. First we
+            // take a guess at version by assuming version will be the minimum, 1:
+            $provisionalBitsNeeded = $headerBits->getSize()
+                + $mode->getCharacterCountBits(Version::getVersionForNumber(1))
+                + $dataBits->getSize();
+            $provisionalVersion = self::chooseVersion($provisionalBitsNeeded, $ecLevel);
+        
             // Use that guess to calculate the right version. I am still not sure
             // this works in 100% of cases.
             $bitsNeeded = $headerBits->getSize()

--- a/src/Writer.php
+++ b/src/Writer.php
@@ -41,7 +41,7 @@ final class Writer
         string $content,
         string $encoding = Encoder::DEFAULT_BYTE_MODE_ECODING,
         ?ErrorCorrectionLevel $ecLevel = null,
-        ?Version $versionNumber = null
+        ?Version $forcedVersion = null
     ) : string {
         if (strlen($content) === 0) {
             throw new InvalidArgumentException('Found empty contents');
@@ -51,7 +51,7 @@ final class Writer
             $ecLevel = ErrorCorrectionLevel::L();
         }
 
-        return $this->renderer->render(Encoder::encode($content, $ecLevel, $encoding, $versionNumber));
+        return $this->renderer->render(Encoder::encode($content, $ecLevel, $encoding, $forcedVersion));
     }
 
     /**
@@ -64,8 +64,8 @@ final class Writer
         string $filename,
         string $encoding = Encoder::DEFAULT_BYTE_MODE_ECODING,
         ?ErrorCorrectionLevel $ecLevel = null,
-        ?Version $versionNumber = null
+        ?Version $forcedVersion = null
     ) : void {
-        file_put_contents($filename, $this->writeString($content, $encoding, $ecLevel, $versionNumber));
+        file_put_contents($filename, $this->writeString($content, $encoding, $ecLevel, $forcedVersion));
     }
 }

--- a/src/Writer.php
+++ b/src/Writer.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 namespace BaconQrCode;
 
 use BaconQrCode\Common\ErrorCorrectionLevel;
+use BaconQrCode\Common\Version;
 use BaconQrCode\Encoder\Encoder;
 use BaconQrCode\Exception\InvalidArgumentException;
 use BaconQrCode\Renderer\RendererInterface;
@@ -39,7 +40,8 @@ final class Writer
     public function writeString(
         string $content,
         string $encoding = Encoder::DEFAULT_BYTE_MODE_ECODING,
-        ?ErrorCorrectionLevel $ecLevel = null
+        ?ErrorCorrectionLevel $ecLevel = null,
+        ?Version $versionNumber = null
     ) : string {
         if (strlen($content) === 0) {
             throw new InvalidArgumentException('Found empty contents');
@@ -49,7 +51,7 @@ final class Writer
             $ecLevel = ErrorCorrectionLevel::L();
         }
 
-        return $this->renderer->render(Encoder::encode($content, $ecLevel, $encoding));
+        return $this->renderer->render(Encoder::encode($content, $ecLevel, $encoding, $versionNumber));
     }
 
     /**
@@ -61,8 +63,9 @@ final class Writer
         string $content,
         string $filename,
         string $encoding = Encoder::DEFAULT_BYTE_MODE_ECODING,
-        ?ErrorCorrectionLevel $ecLevel = null
+        ?ErrorCorrectionLevel $ecLevel = null,
+        ?Version $versionNumber = null
     ) : void {
-        file_put_contents($filename, $this->writeString($content, $encoding, $ecLevel));
+        file_put_contents($filename, $this->writeString($content, $encoding, $ecLevel, $versionNumber));
     }
 }


### PR DESCRIPTION
We have to use a specific QR code version number and i could not find anywhere where to define it.

Our case: 
- script calculated that version number is 10
- we must use version number 15

New Usage example:
``` php
$renderer = new \BaconQrCode\Renderer\ImageRenderer(
    new \BaconQrCode\Renderer\RendererStyle\RendererStyle(256),
    new \BaconQrCode\Renderer\Image\SvgImageBackEnd()
);
$writer = new \BaconQrCode\Writer($renderer);

$output = $writer->writeString(
    '...',
    'ISO-8859-2',
    \BaconQrCode\Common\ErrorCorrectionLevel::forBits(0),
    \BaconQrCode\Common\Version::getVersionForNumber(15)  // <<< THIS IS NEW PARAMETER
);
```
-----
> When version code is not set, then script tries to guess the right version (no changes for current use)
> When script version is set, then script uses that version instead guessing it