### PR TITLE
Add PHP 8.0 compatiblilty

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "require": {
         "php": "^7.1 || ^8.0",
         "ext-iconv": "*",
-        "dasprid/enum": "^1.0"
+        "dasprid/enum": "^1.0.3"
     },
     "suggest": {
         "ext-imagick": "to generate QR code images"

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "license" : "BSD-2-Clause",
     "homepage": "https://github.com/Bacon/BaconQrCode",
     "require": {
-        "php": "^7.1",
+        "php": "^7.1 || ^8.0",
         "ext-iconv": "*",
         "dasprid/enum": "^1.0"
     },


### PR DESCRIPTION
The last travis build on PHP 8.0.0-dev seemed OK.
https://travis-ci.org/github/Bacon/BaconQrCode/jobs/713385594

I think this library can be marked as compatible with PHP 8 as the first release candidate will be released next week.