### PR TITLE
Make EPS & SVG Rendering usable on international locales

### DIFF
--- a/src/Renderer/Image/EpsImageBackEnd.php
+++ b/src/Renderer/Image/EpsImageBackEnd.php
@@ -75,7 +75,7 @@ final class EpsImageBackEnd implements ImageBackEndInterface
             throw new RuntimeException('No image has been started');
         }
 
-        $this->eps .= sprintf("%1\$s %1\$s s\n", round($size, self::PRECISION));
+        $this->eps .= sprintf("%1\$1.".self::PRECISION."F %1\$1.".self::PRECISION."F s\n", round($size, self::PRECISION));
     }
 
     public function translate(float $x, float $y) : void
@@ -84,7 +84,7 @@ final class EpsImageBackEnd implements ImageBackEndInterface
             throw new RuntimeException('No image has been started');
         }
 
-        $this->eps .= sprintf("%s %s t\n", round($x, self::PRECISION), round($y, self::PRECISION));
+        $this->eps .= sprintf("%1.".self::PRECISION."F %1.".self::PRECISION."F t\n", round($x, self::PRECISION), round($y, self::PRECISION));
     }
 
     public function rotate(int $degrees) : void
@@ -176,13 +176,13 @@ final class EpsImageBackEnd implements ImageBackEndInterface
                 case $op instanceof Move:
                     $fromX = $toX = round($op->getX(), self::PRECISION);
                     $fromY = $toY = round($op->getY(), self::PRECISION);
-                    $pathData[] = sprintf('%s %s m', $toX, $toY);
+                    $pathData[] = sprintf('%1.".self::PRECISION."F %1.".self::PRECISION."F m', $toX, $toY);
                     break;
 
                 case $op instanceof Line:
                     $fromX = $toX = round($op->getX(), self::PRECISION);
                     $fromY = $toY = round($op->getY(), self::PRECISION);
-                    $pathData[] = sprintf('%s %s l', $toX, $toY);
+                    $pathData[] = sprintf('%1.".self::PRECISION."F %1.".self::PRECISION."F l', $toX, $toY);
                     break;
 
                 case $op instanceof EllipticArc:
@@ -196,7 +196,7 @@ final class EpsImageBackEnd implements ImageBackEndInterface
                     $y2 = round($op->getY2(), self::PRECISION);
                     $fromX = $x3 = round($op->getX3(), self::PRECISION);
                     $fromY = $y3 = round($op->getY3(), self::PRECISION);
-                    $pathData[] = sprintf('%s %s %s %s %s %s c', $x1, $y1, $x2, $y2, $x3, $y3);
+                    $pathData[] = sprintf('%1.".self::PRECISION."F %1.".self::PRECISION."F %1.".self::PRECISION."F %1.".self::PRECISION."F %1.".self::PRECISION."F %1.".self::PRECISION."F c', $x1, $y1, $x2, $y2, $x3, $y3);
                     break;
 
                 case $op instanceof Close:
@@ -271,7 +271,7 @@ final class EpsImageBackEnd implements ImageBackEndInterface
         switch ($gradient->getType()) {
             case GradientType::HORIZONTAL():
                 $this->eps .= sprintf(
-                    " /Coords [ %s %s %s %s ]\n",
+                    " /Coords [ %1.".self::PRECISION."F %1.".self::PRECISION."F %1.".self::PRECISION."F %1.".self::PRECISION."F ]\n",
                     round($x, self::PRECISION),
                     round($y, self::PRECISION),
                     round($x + $width, self::PRECISION),
@@ -281,7 +281,7 @@ final class EpsImageBackEnd implements ImageBackEndInterface
 
             case GradientType::VERTICAL():
                 $this->eps .= sprintf(
-                    " /Coords [ %s %s %s %s ]\n",
+                    " /Coords [ %1.".self::PRECISION."F %1.".self::PRECISION."F %1.".self::PRECISION."F %1.".self::PRECISION."F ]\n",
                     round($x, self::PRECISION),
                     round($y, self::PRECISION),
                     round($x, self::PRECISION),
@@ -291,7 +291,7 @@ final class EpsImageBackEnd implements ImageBackEndInterface
 
             case GradientType::DIAGONAL():
                 $this->eps .= sprintf(
-                    " /Coords [ %s %s %s %s ]\n",
+                    " /Coords [ %1.".self::PRECISION."F %1.".self::PRECISION."F %1.".self::PRECISION."F %1.".self::PRECISION."F ]\n",
                     round($x, self::PRECISION),
                     round($y, self::PRECISION),
                     round($x + $width, self::PRECISION),
@@ -301,7 +301,7 @@ final class EpsImageBackEnd implements ImageBackEndInterface
 
             case GradientType::INVERSE_DIAGONAL():
                 $this->eps .= sprintf(
-                    " /Coords [ %s %s %s %s ]\n",
+                    " /Coords [ %1.".self::PRECISION."F %1.".self::PRECISION."F %1.".self::PRECISION."F %1.".self::PRECISION."F ]\n",
                     round($x, self::PRECISION),
                     round($y + $height, self::PRECISION),
                     round($x + $width, self::PRECISION),
@@ -314,7 +314,7 @@ final class EpsImageBackEnd implements ImageBackEndInterface
                 $centerY = ($y + $height) / 2;
 
                 $this->eps .= sprintf(
-                    " /Coords [ %s %s 0 %s %s %s ]\n",
+                    " /Coords [ %1.".self::PRECISION."F %1.".self::PRECISION."F 0 %1.".self::PRECISION."F %1.".self::PRECISION."F %1.".self::PRECISION."F ]\n",
                     round($centerX, self::PRECISION),
                     round($centerY, self::PRECISION),
                     round($centerX, self::PRECISION),
@@ -354,12 +354,12 @@ final class EpsImageBackEnd implements ImageBackEndInterface
     private function getColorString(ColorInterface $color) : string
     {
         if ($color instanceof Rgb) {
-            return sprintf('%s %s %s', $color->getRed() / 255, $color->getGreen() / 255, $color->getBlue() / 255);
+            return sprintf("%1.".self::PRECISION."F %1.".self::PRECISION."F %1.".self::PRECISION."F", $color->getRed() / 255, $color->getGreen() / 255, $color->getBlue() / 255);
         }
 
         if ($color instanceof Cmyk) {
             return sprintf(
-                '%s %s %s %s',
+                "% %1.".self::PRECISION."F %1.".self::PRECISION."F %1.".self::PRECISION."F",
                 $color->getCyan() / 100,
                 $color->getMagenta() / 100,
                 $color->getYellow() / 100,
@@ -368,7 +368,7 @@ final class EpsImageBackEnd implements ImageBackEndInterface
         }
 
         if ($color instanceof Gray) {
-            return sprintf('%s', $color->getGray() / 100);
+            return sprintf("%1.".self::PRECISION."F", $color->getGray() / 100);
         }
 
         return $this->getColorString($color->toCmyk());

--- a/src/Renderer/Image/SvgImageBackEnd.php
+++ b/src/Renderer/Image/SvgImageBackEnd.php
@@ -97,7 +97,7 @@ final class SvgImageBackEnd implements ImageBackEndInterface
         $this->xmlWriter->startElement('g');
         $this->xmlWriter->writeAttribute(
             'transform',
-            sprintf('scale(%s)', round($size, self::PRECISION))
+            sprintf('scale(%1.'.self::PRECISION.'F)', round($size, self::PRECISION))
         );
         ++$this->stack[$this->currentStack];
     }
@@ -111,7 +111,7 @@ final class SvgImageBackEnd implements ImageBackEndInterface
         $this->xmlWriter->startElement('g');
         $this->xmlWriter->writeAttribute(
             'transform',
-            sprintf('translate(%s,%s)', round($x, self::PRECISION), round($y, self::PRECISION))
+            sprintf('translate(%1.'.self::PRECISION.'F,%1.'.self::PRECISION.'F)', round($x, self::PRECISION), round($y, self::PRECISION))
         );
         ++$this->stack[$this->currentStack];
     }
@@ -222,7 +222,7 @@ final class SvgImageBackEnd implements ImageBackEndInterface
             switch (true) {
                 case $op instanceof Move:
                     $pathData[] = sprintf(
-                        'M%s %s',
+                        'M%1.'.self::PRECISION.'F %1.'.self::PRECISION.'F',
                         round($op->getX(), self::PRECISION),
                         round($op->getY(), self::PRECISION)
                     );
@@ -230,7 +230,7 @@ final class SvgImageBackEnd implements ImageBackEndInterface
 
                 case $op instanceof Line:
                     $pathData[] = sprintf(
-                        'L%s %s',
+                        'L%1.'.self::PRECISION.'F %1.'.self::PRECISION.'F',
                         round($op->getX(), self::PRECISION),
                         round($op->getY(), self::PRECISION)
                     );
@@ -238,7 +238,7 @@ final class SvgImageBackEnd implements ImageBackEndInterface
 
                 case $op instanceof EllipticArc:
                     $pathData[] = sprintf(
-                        'A%s %s %s %u %u %s %s',
+                        'A%1.'.self::PRECISION.'F %1.'.self::PRECISION.'F %1.'.self::PRECISION.'F %u %u %1.'.self::PRECISION.'F %1.'.self::PRECISION.'F',
                         round($op->getXRadius(), self::PRECISION),
                         round($op->getYRadius(), self::PRECISION),
                         round($op->getXAxisAngle(), self::PRECISION),
@@ -251,7 +251,7 @@ final class SvgImageBackEnd implements ImageBackEndInterface
 
                 case $op instanceof Curve:
                     $pathData[] = sprintf(
-                        'C%s %s %s %s %s %s',
+                        'C%1.'.self::PRECISION.'F %1.'.self::PRECISION.'F %1.'.self::PRECISION.'F %1.'.self::PRECISION.'F %1.'.self::PRECISION.'F %1.'.self::PRECISION.'F',
                         round($op->getX1(), self::PRECISION),
                         round($op->getY1(), self::PRECISION),
                         round($op->getX2(), self::PRECISION),


### PR DESCRIPTION
Funnily enough - This does not fix the Imagick rendering as even the base PHP function of ImagickDraw::scale(float, float) does fail on international locale with floats. But it does take care of localized numeric transformations giving broken SVGs when using the library, it's at least usable with the svg and eps backends without giving spontaneous errors.

I also opened an issue there: https://github.com/Imagick/imagick/issues/404

The error you're seeing when using Imagick Backend on an international locale is going to be 'non-conforming drawing primitive definition `'

I'm probably still going to use an en_US locale now and do numeric transformations manually instead of via PHP instead. But it's anyway a good idea to support other locales, so this is at least an improvement over the original.