### PR TITLE
Add paths and folders to be export-ignored to .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,6 @@
 /.gitignore export-ignore
 /.travis.yml export-ignore
 /phpcs.xml export-ignore
+/phpunit.xml.dist export-ignore
+/CHANGELOG.md export-ignore
+/test export-ignore


### PR DESCRIPTION
Add paths to `.gitattributes` with the `export-ignore` flag set, so they're not pulled down as part of a project's dependencies via Composer.