### PR TITLE
Non-locale aware of scale and translate

### DIFF
--- a/src/Renderer/Image/SvgImageBackEnd.php
+++ b/src/Renderer/Image/SvgImageBackEnd.php
@@ -97,7 +97,7 @@ final class SvgImageBackEnd implements ImageBackEndInterface
         $this->xmlWriter->startElement('g');
         $this->xmlWriter->writeAttribute(
             'transform',
-            sprintf('scale(%s)', round($size, self::PRECISION))
+            sprintf('scale(%.' . self::PRECISION . 'F)', round($size, self::PRECISION))
         );
         ++$this->stack[$this->currentStack];
     }
@@ -111,7 +111,7 @@ final class SvgImageBackEnd implements ImageBackEndInterface
         $this->xmlWriter->startElement('g');
         $this->xmlWriter->writeAttribute(
             'transform',
-            sprintf('translate(%s,%s)', round($x, self::PRECISION), round($y, self::PRECISION))
+            sprintf('translate(%.' . self::PRECISION . 'F,%.' . self::PRECISION . 'F)', round($x, self::PRECISION), round($y, self::PRECISION))
         );
         ++$this->stack[$this->currentStack];
     }

--- a/src/Renderer/Image/SvgImageBackEnd.php
+++ b/src/Renderer/Image/SvgImageBackEnd.php
@@ -19,6 +19,8 @@ use XMLWriter;
 final class SvgImageBackEnd implements ImageBackEndInterface
 {
     private const PRECISION = 3;
+    private const SCALE_FORMAT = 'scale(%.' . self::PRECISION . 'F)';
+    private const TRANSLATE_FORMAT = 'translate(%.' . self::PRECISION . 'F,%.' . self::PRECISION . 'F)';
 
     /**
      * @var XMLWriter|null
@@ -97,7 +99,7 @@ final class SvgImageBackEnd implements ImageBackEndInterface
         $this->xmlWriter->startElement('g');
         $this->xmlWriter->writeAttribute(
             'transform',
-            sprintf('scale(%.' . self::PRECISION . 'F)', round($size, self::PRECISION))
+            sprintf(self::SCALE_FORMAT, round($size, self::PRECISION))
         );
         ++$this->stack[$this->currentStack];
     }
@@ -111,7 +113,7 @@ final class SvgImageBackEnd implements ImageBackEndInterface
         $this->xmlWriter->startElement('g');
         $this->xmlWriter->writeAttribute(
             'transform',
-            sprintf('translate(%.' . self::PRECISION . 'F,%.' . self::PRECISION . 'F)', round($x, self::PRECISION), round($y, self::PRECISION))
+            sprintf(self::TRANSLATE_FORMAT, round($x, self::PRECISION), round($y, self::PRECISION))
         );
         ++$this->stack[$this->currentStack];
     }


### PR DESCRIPTION
When using a Slovenian locale, output of scale and translate is wrong. 

Expected result: `scale(3.123)`
Actual result: `scale(3,123)` which means wrong scale
Issue: Slovenian decimal separator is ',' and not a '.' (https://www.localeplanet.com/icu/sl-SI/index.html)

Solution: when using a `sprintf` use a non-local aware float formatting.

Test code
``` php
$precision = 3;
$size = 3.1234;

$xml = new \XMLWriter();
$xml->openMemory();
$xml->startDocument('1.0', 'UTF-8');
$xml->startElement('svg');
$xml->writeAttribute('xmlns', 'http://www.w3.org/2000/svg');
$xml->writeAttribute('version', '1.1');
$xml->writeAttribute('width', (string) $size);
$xml->writeAttribute('height', (string) $size);
$xml->writeAttribute('viewBox', '0 0 '. $size . ' ' . $size);

// ========= Current code
// English: 3.1234
// Result is scale for x and y the same = 3.1234
setlocale(LC_ALL, array('English', 'en', 'en_GB.UTF-8'));
$xml->startElement('g');
$xml->writeAttribute(
    'transform',
    sprintf('scale(%s)', round($size, $precision))
);
$xml->text("English");
$xml->endElement();

// Slovenian: 3,1234
// Result is scale in x=3 and y=1234
setlocale(LC_ALL,array('sl_SI.UTF-8', 'Slovenian', 'sl_SI'));
$xml->startElement('g');
$xml->writeAttribute(
    'transform',
    sprintf('scale(%s)', round($size, $precision))
);
$xml->text("Slovenian with a bug");
$xml->endElement();

// ========= With fixed code
// Using a 'F': The argument is treated as a float and presented as a floating-point number (non-locale aware)
setlocale(LC_ALL, array('English', 'en', 'en_GB.UTF-8'));
$xml->startElement('g');
$xml->writeAttribute(
    'transform',
    sprintf('scale(%.' . $precision . 'F)', round($size, $precision))
);
$xml->text("English");
$xml->endElement();
setlocale(LC_ALL,array('sl_SI.UTF-8', 'Slovenian', 'sl_SI'));
$xml->startElement('g');
$xml->writeAttribute(
    'transform',
    sprintf('scale(%.' . $precision . 'F)', round($size, $precision))
);
$xml->text("Slovenian fixed");
$xml->endElement();

$xml->endDocument();
echo $xml->outputMemory();
```
Test code result
``` xml
<?xml version="1.0" encoding="UTF-8"?>
<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="3.1234" height="3.1234" viewBox="0 0 3.1234 3.1234">
    <g transform="scale(3.123)">English</g>
    <g transform="scale(3,123)">Slovenian with a bug</g>
    <g transform="scale(3.123)">English</g>
    <g transform="scale(3.123)">Slovenian fixed</g>
</svg>
```