### PR TITLE
Allow a center cutout for insertion of logo, image, text, etc.

### DIFF
--- a/src/Renderer/ImageRenderer.php
+++ b/src/Renderer/ImageRenderer.php
@@ -47,6 +47,20 @@ final class ImageRenderer implements RendererInterface
         $moduleSize = $size / $totalSize;
         $fill = $this->rendererStyle->getFill();
 
+        $cutoutWidth = $this->rendererStyle->getCutoutWidth();
+        $cutoutHeight = $this->rendererStyle->getCutoutHeight();
+        $cutoutModuleWidth = (int) ($cutoutWidth / $moduleSize);
+        if ($cutoutModuleWidth % 2 == 0) $cutoutModuleWidth++;
+        $cutoutModuleHeight = (int) ($cutoutHeight / $moduleSize);
+        if ($cutoutModuleHeight % 2 == 0) $cutoutModuleHeight++;
+        $xStart = (int) ($totalSize / 2 - $cutoutModuleWidth / 2);
+        $yStart = (int) ($totalSize / 2 - $cutoutModuleHeight / 2);
+        for ($y = 0; $y < $cutoutModuleHeight; ++$y) {
+            for ($x = 0; $x < $cutoutModuleWidth; ++$x) {
+                $matrix->set($xStart + $x, $yStart + $y, 0);
+            }
+        }
+
         $this->imageBackEnd->new($size, $fill->getBackgroundColor());
         $this->imageBackEnd->scale((float) $moduleSize);
         $this->imageBackEnd->translate((float) $margin, (float) $margin);

--- a/src/Renderer/ImageRenderer.php
+++ b/src/Renderer/ImageRenderer.php
@@ -62,7 +62,6 @@ final class ImageRenderer implements RendererInterface
           $yStart = (int) ($totalSize / 2 - $cutoutModuleHeight / 2);
           for ($y = 0; $y < $cutoutModuleHeight; ++$y) {
               for ($x = 0; $x < $cutoutModuleWidth; ++$x) {
-                  print $xStart + $x . ', ' . $yStart + $y;
                   $matrix->set($xStart + $x, $yStart + $y, 0);
               }
           }

--- a/src/Renderer/ImageRenderer.php
+++ b/src/Renderer/ImageRenderer.php
@@ -50,21 +50,21 @@ final class ImageRenderer implements RendererInterface
         $cutoutWidth = $this->rendererStyle->getCutoutWidth();
         $cutoutHeight = $this->rendererStyle->getCutoutHeight();
         if ($cutoutWidth > 0 && $cutoutHeight > 0) {
-          $cutoutModuleWidth = (int) ($cutoutWidth / $moduleSize);
-          if ($cutoutModuleWidth % 2 == 0) {
-              $cutoutModuleWidth++;
-          }
-          $cutoutModuleHeight = (int) ($cutoutHeight / $moduleSize);
-          if ($cutoutModuleHeight % 2 == 0) {
-              $cutoutModuleHeight++;
-          }
-          $xStart = (int) ($totalSize / 2 - $cutoutModuleWidth / 2);
-          $yStart = (int) ($totalSize / 2 - $cutoutModuleHeight / 2);
-          for ($y = 0; $y < $cutoutModuleHeight; ++$y) {
-              for ($x = 0; $x < $cutoutModuleWidth; ++$x) {
-                  $matrix->set($xStart + $x, $yStart + $y, 0);
-              }
-          }
+            $cutoutModuleWidth = (int) ($cutoutWidth / $moduleSize);
+            if ($cutoutModuleWidth % 2 == 0) {
+                $cutoutModuleWidth++;
+            }
+            $cutoutModuleHeight = (int) ($cutoutHeight / $moduleSize);
+            if ($cutoutModuleHeight % 2 == 0) {
+                $cutoutModuleHeight++;
+            }
+            $xStart = (int) ($totalSize / 2 - $cutoutModuleWidth / 2);
+            $yStart = (int) ($totalSize / 2 - $cutoutModuleHeight / 2);
+            for ($y = 0; $y < $cutoutModuleHeight; ++$y) {
+                for ($x = 0; $x < $cutoutModuleWidth; ++$x) {
+                    $matrix->set($xStart + $x, $yStart + $y, 0);
+                }
+            }
         }
 
         $this->imageBackEnd->new($size, $fill->getBackgroundColor());

--- a/src/Renderer/ImageRenderer.php
+++ b/src/Renderer/ImageRenderer.php
@@ -49,20 +49,23 @@ final class ImageRenderer implements RendererInterface
 
         $cutoutWidth = $this->rendererStyle->getCutoutWidth();
         $cutoutHeight = $this->rendererStyle->getCutoutHeight();
-        $cutoutModuleWidth = (int) ($cutoutWidth / $moduleSize);
-        if ($cutoutModuleWidth % 2 == 0) {
-            $cutoutModuleWidth++;
-        }
-        $cutoutModuleHeight = (int) ($cutoutHeight / $moduleSize);
-        if ($cutoutModuleHeight % 2 == 0) {
-            $cutoutModuleHeight++;
-        }
-        $xStart = (int) ($totalSize / 2 - $cutoutModuleWidth / 2);
-        $yStart = (int) ($totalSize / 2 - $cutoutModuleHeight / 2);
-        for ($y = 0; $y < $cutoutModuleHeight; ++$y) {
-            for ($x = 0; $x < $cutoutModuleWidth; ++$x) {
-                $matrix->set($xStart + $x, $yStart + $y, 0);
-            }
+        if ($cutoutWidth > 0 && $cutoutHeight > 0) {
+          $cutoutModuleWidth = (int) ($cutoutWidth / $moduleSize);
+          if ($cutoutModuleWidth % 2 == 0) {
+              $cutoutModuleWidth++;
+          }
+          $cutoutModuleHeight = (int) ($cutoutHeight / $moduleSize);
+          if ($cutoutModuleHeight % 2 == 0) {
+              $cutoutModuleHeight++;
+          }
+          $xStart = (int) ($totalSize / 2 - $cutoutModuleWidth / 2);
+          $yStart = (int) ($totalSize / 2 - $cutoutModuleHeight / 2);
+          for ($y = 0; $y < $cutoutModuleHeight; ++$y) {
+              for ($x = 0; $x < $cutoutModuleWidth; ++$x) {
+                  print $xStart + $x . ', ' . $yStart + $y;
+                  $matrix->set($xStart + $x, $yStart + $y, 0);
+              }
+          }
         }
 
         $this->imageBackEnd->new($size, $fill->getBackgroundColor());

--- a/src/Renderer/ImageRenderer.php
+++ b/src/Renderer/ImageRenderer.php
@@ -50,9 +50,13 @@ final class ImageRenderer implements RendererInterface
         $cutoutWidth = $this->rendererStyle->getCutoutWidth();
         $cutoutHeight = $this->rendererStyle->getCutoutHeight();
         $cutoutModuleWidth = (int) ($cutoutWidth / $moduleSize);
-        if ($cutoutModuleWidth % 2 == 0) $cutoutModuleWidth++;
+        if ($cutoutModuleWidth % 2 == 0) {
+            $cutoutModuleWidth++;
+        }
         $cutoutModuleHeight = (int) ($cutoutHeight / $moduleSize);
-        if ($cutoutModuleHeight % 2 == 0) $cutoutModuleHeight++;
+        if ($cutoutModuleHeight % 2 == 0) {
+            $cutoutModuleHeight++;
+        }
         $xStart = (int) ($totalSize / 2 - $cutoutModuleWidth / 2);
         $yStart = (int) ($totalSize / 2 - $cutoutModuleHeight / 2);
         for ($y = 0; $y < $cutoutModuleHeight; ++$y) {

--- a/src/Renderer/RendererStyle/RendererStyle.php
+++ b/src/Renderer/RendererStyle/RendererStyle.php
@@ -35,18 +35,32 @@ final class RendererStyle
      */
     private $fill;
 
+    /**
+     * @var int
+     */
+    private $cutoutWidth;
+
+    /**
+     * @var int
+     */
+    private $cutoutHeight;
+
     public function __construct(
         int $size,
         int $margin = 4,
         ?ModuleInterface $module = null,
         ?EyeInterface $eye = null,
-        ?Fill $fill = null
+        ?Fill $fill = null,
+        int $cutoutWidth = 0,
+        int $cutoutHeight = 0
     ) {
         $this->margin = $margin;
         $this->size = $size;
         $this->module = $module ?: SquareModule::instance();
         $this->eye = $eye ?: new ModuleEye($this->module);
         $this->fill = $fill ?: Fill::default();
+        $this->cutoutWidth = $cutoutWidth;
+        $this->cutoutHeight = $cutoutHeight;
     }
 
     public function withSize(int $size) : self
@@ -86,5 +100,15 @@ final class RendererStyle
     public function getFill() : Fill
     {
         return $this->fill;
+    }
+
+    public function getCutoutWidth() : int
+    {
+        return $this->cutoutWidth;
+    }
+
+    public function getCutoutHeight() : int
+    {
+        return $this->cutoutHeight;
     }
 }


### PR DESCRIPTION
Potentially a slightly more controversial request, but a lot of QR codes can be seen with a logo or similar in the center.

Yes you could just slap one on afterwards, but it looks a lot cleaner if it's achieved by module clearing first.