### PR TITLE
Add PHP 8.2 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       matrix:
         operating-system: [ubuntu-latest]
-        php-versions: ['7.4', '8.0', '8.1']
+        php-versions: ['7.4', '8.0', '8.1', '8.2']
     runs-on: ${{ matrix.operating-system }}
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
This PR aims to see if any changes are needed for PHP 8.2. If not it can safely be merged.

In addition to that it also removes PHP 7.4 as it is no longer maintained (EOL).