### PR TITLE
Debian adjustments and project improvements

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,6 +2,5 @@
 /.gitignore export-ignore
 /.github export-ignore
 /phpcs.xml export-ignore
-/phpunit.xml.dist export-ignore
 /CHANGELOG.md export-ignore
 /Dockerfile export-ignore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -30,7 +30,7 @@ jobs:
         php-versions: ['7.4', '8.0', '8.1', '8.2']
     runs-on: ${{ matrix.operating-system }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -57,6 +57,6 @@ jobs:
         run: vendor/bin/phpunit --coverage-clover clover.xml
 
       - name: Codecov
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v3
         with:
           files: ./clover.xml

--- a/composer.json
+++ b/composer.json
@@ -34,5 +34,11 @@
         "allow-plugins": {
             "ocramius/package-versions": true
         }
+    },
+    "archive": {
+        "exclude": [
+            "/test",
+            "/phpunit.xml.dist"
+        ]
     }
 }

--- a/test/Integration/ImagickRenderingTest.php
+++ b/test/Integration/ImagickRenderingTest.php
@@ -17,6 +17,9 @@ use BaconQrCode\Writer;
 use PHPUnit\Framework\TestCase;
 use Spatie\Snapshots\MatchesSnapshots;
 
+/**
+ * @group integration
+ */
 final class ImagickRenderingTest extends TestCase
 {
     use MatchesSnapshots;

--- a/test/Integration/ImagickRenderingTest.php
+++ b/test/Integration/ImagickRenderingTest.php
@@ -21,6 +21,9 @@ final class ImagickRenderingTest extends TestCase
 {
     use MatchesSnapshots;
 
+    /**
+     * @requires extension imagick
+     */
     public function testGenericQrCode() : void
     {
         $renderer = new ImageRenderer(
@@ -35,6 +38,9 @@ final class ImagickRenderingTest extends TestCase
         unlink($tempName);
     }
 
+    /**
+     * @requires extension imagick
+     */
     public function testIssue79() : void
     {
         $eye = SquareEye::instance();


### PR DESCRIPTION
Since the last version that added a new dependency to run tests I can not package it in Debian, I made one adjustment to allow me to `--exclude-group integration` and just have to remove `use MatchesSnapshots;` on Debian.

I also made changes to make everybody happy, exclude the tests from composer archives  and allow me to have them in Debian