### PR TITLE
Fix Shift-JIS throwing Unsupported operand Error

### DIFF
--- a/src/Encoder/Encoder.php
+++ b/src/Encoder/Encoder.php
@@ -217,7 +217,7 @@ final class Encoder
         }
 
         for ($i = 0; $i < $length; $i += 2) {
-            $byte = $bytes[$i] & 0xff;
+            $byte = $bytes[$i] . 0xff;
 
             if (($byte < 0x81 || $byte > 0x9f) && $byte < 0xe0 || $byte > 0xeb) {
                 return false;

--- a/src/Encoder/Encoder.php
+++ b/src/Encoder/Encoder.php
@@ -217,7 +217,7 @@ final class Encoder
         }
 
         for ($i = 0; $i < $length; $i += 2) {
-            $byte = $bytes[$i] . 0xff;
+            $byte = ord($bytes[$i]);
 
             if (($byte < 0x81 || $byte > 0x9f) && $byte < 0xe0 || $byte > 0xeb) {
                 return false;

--- a/test/Encoder/EncoderTest.php
+++ b/test/Encoder/EncoderTest.php
@@ -484,4 +484,16 @@ final class EncoderTest extends TestCase
         );
         $this->assertEquals($expected, $ecBytes);
     }
+
+    public function testIsOnlyDoubleByteKanji() : void
+    {
+        // No Double-Byte Kanji
+        $this->assertFalse($this->methods['isOnlyDoubleByteKanji']->invoke(null, "1"));
+
+        // Mixed Double-Byte Kanji and ASCII
+        $this->assertFalse($this->methods['isOnlyDoubleByteKanji']->invoke(null, "文字 ASCII 123"));
+
+        // Only Double-Byte Kanji
+        $this->assertTrue($this->methods['isOnlyDoubleByteKanji']->invoke(null, "こんにちは"));
+    }
 }

--- a/test/Encoder/EncoderTest.php
+++ b/test/Encoder/EncoderTest.php
@@ -488,12 +488,12 @@ final class EncoderTest extends TestCase
     public function testIsOnlyDoubleByteKanji() : void
     {
         // No Double-Byte Kanji
-        $this->assertFalse($this->methods['isOnlyDoubleByteKanji']->invoke(null, "1"));
+        $this->assertFalse($this->methods['isOnlyDoubleByteKanji']->invoke(null, '1'));
 
         // Mixed Double-Byte Kanji and ASCII
-        $this->assertFalse($this->methods['isOnlyDoubleByteKanji']->invoke(null, "文字 ASCII 123"));
+        $this->assertFalse($this->methods['isOnlyDoubleByteKanji']->invoke(null, '文字 ASCII 123'));
 
         // Only Double-Byte Kanji
-        $this->assertTrue($this->methods['isOnlyDoubleByteKanji']->invoke(null, "こんにちは"));
+        $this->assertTrue($this->methods['isOnlyDoubleByteKanji']->invoke(null, 'こんにちは'));
     }
 }


### PR DESCRIPTION
This will fix ` private static function isOnlyDoubleByteKanji(string $content) : bool` throwing "Unsupported operand types: string & int" when using SHIFT-JIS encoding.

<img width="800" alt="image" src="https://user-images.githubusercontent.com/7894265/211293518-fa865c4d-c951-4c5b-af07-5085ad6b9c2d.png">
