### PR TITLE
Add test folder to gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,3 +4,5 @@
 /phpcs.xml export-ignore
 /CHANGELOG.md export-ignore
 /Dockerfile export-ignore
+/test/ export-ignore
+phpunit.xml.dist export-ignore


### PR DESCRIPTION
Hi @DASPRiD, 

Currently when installing the library, we test folder is downloaded but not needed.
This can be avoided by added the test folder to the export-ignore list in gitattributes.