### PR TITLE
feat: make utf-8 eci prefix configurable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM php:8.1-cli
 
 COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
-RUN apt-get update && apt-get install -y libmagickwand-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
-RUN pecl install imagick && docker-php-ext-enable imagick
+RUN apt-get update && apt-get install -y libmagickwand-dev libzip-dev zip --no-install-recommends && rm -rf /var/lib/apt/lists/*
+RUN pecl install imagick && docker-php-ext-enable imagick && docker-php-ext-install zip
 RUN alias composer='php /usr/bin/composer'
 
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM php:8.1-cli
 
 COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
-RUN apt-get update && apt-get install -y libmagickwand-dev libzip-dev zip --no-install-recommends && rm -rf /var/lib/apt/lists/*
-RUN pecl install imagick && docker-php-ext-enable imagick && docker-php-ext-install zip
+RUN apt-get update && apt-get install -y libmagickwand-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
+RUN pecl install imagick && docker-php-ext-enable imagick
 RUN alias composer='php /usr/bin/composer'
 
 WORKDIR /app

--- a/src/Encoder/Encoder.php
+++ b/src/Encoder/Encoder.php
@@ -48,7 +48,9 @@ final class Encoder
         string $content,
         ErrorCorrectionLevel $ecLevel,
         string $encoding = self::DEFAULT_BYTE_MODE_ECODING,
-        ?Version $forcedVersion = null
+        ?Version $forcedVersion = null,
+        // Barcode scanner might not be able to read the encoded message of the QR code with the prefix ECI of UTF-8
+        bool $prefixEci = true
     ) : QrCode {
         // Pick an encoding mode appropriate for the content. Note that this
         // will not attempt to use multiple modes / segments even if that were
@@ -60,7 +62,7 @@ final class Encoder
         $headerBits = new BitArray();
 
         // Append ECI segment if applicable
-        if (Mode::BYTE() === $mode && self::DEFAULT_BYTE_MODE_ECODING !== $encoding) {
+        if ($prefixEci && Mode::BYTE() === $mode && self::DEFAULT_BYTE_MODE_ECODING !== $encoding) {
             $eci = CharacterSetEci::getCharacterSetEciByName($encoding);
 
             if (null !== $eci) {

--- a/test/Encoder/EncoderTest.php
+++ b/test/Encoder/EncoderTest.php
@@ -160,6 +160,41 @@ final class EncoderTest extends TestCase
         $this->assertSame($expected, (string) $qrCode);
     }
 
+    public function testSimpleUtf8WithoutEci() : void
+    {
+        $qrCode = Encoder::encode('hello', ErrorCorrectionLevel::H(), 'utf-8', null, false);
+        $expected = "<<\n"
+            . " mode: BYTE\n"
+            . " ecLevel: H\n"
+            . " version: 1\n"
+            . " maskPattern: 6\n"
+            . " matrix:\n"
+            . " 1 1 1 1 1 1 1 0 0 0 0 0 1 0 1 1 1 1 1 1 1\n"
+            . " 1 0 0 0 0 0 1 0 0 0 0 0 0 0 1 0 0 0 0 0 1\n"
+            . " 1 0 1 1 1 0 1 0 1 1 0 1 0 0 1 0 1 1 1 0 1\n"
+            . " 1 0 1 1 1 0 1 0 1 0 1 0 0 0 1 0 1 1 1 0 1\n"
+            . " 1 0 1 1 1 0 1 0 0 0 1 1 1 0 1 0 1 1 1 0 1\n"
+            . " 1 0 0 0 0 0 1 0 0 0 1 0 0 0 1 0 0 0 0 0 1\n"
+            . " 1 1 1 1 1 1 1 0 1 0 1 0 1 0 1 1 1 1 1 1 1\n"
+            . " 0 0 0 0 0 0 0 0 0 1 1 1 0 0 0 0 0 0 0 0 0\n"
+            . " 0 0 0 1 1 0 1 1 0 1 1 1 0 0 0 0 0 1 1 0 0\n"
+            . " 1 0 1 0 0 1 0 1 0 1 1 0 0 0 1 1 1 1 1 0 0\n"
+            . " 1 1 0 1 0 1 1 0 1 1 0 1 0 1 0 1 0 0 1 1 1\n"
+            . " 1 1 0 0 1 1 0 1 0 1 0 0 1 1 0 1 1 0 1 0 0\n"
+            . " 0 1 0 0 1 1 1 1 1 0 0 0 0 0 1 1 1 1 0 1 0\n"
+            . " 0 0 0 0 0 0 0 0 1 0 1 0 1 1 1 0 0 1 0 1 0\n"
+            . " 1 1 1 1 1 1 1 0 1 0 1 0 0 0 1 0 0 0 1 0 0\n"
+            . " 1 0 0 0 0 0 1 0 0 1 1 1 0 1 0 0 0 1 1 1 1\n"
+            . " 1 0 1 1 1 0 1 0 1 0 1 0 1 0 0 0 1 1 0 1 1\n"
+            . " 1 0 1 1 1 0 1 0 1 0 1 1 1 1 0 0 1 0 0 0 0\n"
+            . " 1 0 1 1 1 0 1 0 0 0 1 1 0 1 1 1 1 1 1 1 1\n"
+            . " 1 0 0 0 0 0 1 0 0 1 1 1 1 1 1 1 1 1 1 1 1\n"
+            . " 1 1 1 1 1 1 1 0 0 0 1 0 0 1 0 0 0 0 0 0 0\n"
+            . ">>\n";
+
+        $this->assertSame($expected, (string) $qrCode);
+    }
+
     public function testAppendModeInfo() : void
     {
         $bits = new BitArray();


### PR DESCRIPTION
# Motivation

Some barcode scanners won't be able to read QR code that is prepended with UTF-8 ECI block, so we want to make the prefix configurable in the library that we utilize in our project [endroid/qr-code-bundle](https://github.com/endroid/qr-code-bundle)

## Changes
- Add a new parameter to the `Encoder::encode` function
- Adjust the Dockerfile
> While building the docker image, we ran into errors and some depenencies were missing. After the modification, we were able to build the image and conducted the tests.