### PR TITLE
Rename test class to match filename

### DIFF
--- a/test/Common/ReedSolomonCodecTest.php
+++ b/test/Common/ReedSolomonCodecTest.php
@@ -7,7 +7,7 @@ use BaconQrCode\Common\ReedSolomonCodec;
 use PHPUnit\Framework\TestCase;
 use SplFixedArray;
 
-class ReedSolomonTest extends TestCase
+class ReedSolomonCodecTest extends TestCase
 {
     public function tabs() : array
     {


### PR DESCRIPTION
Having phpunit test classes not matching their file names has been deprecated since phpunit 9 and was removed in phpunit 10.

* https://github.com/sebastianbergmann/phpunit/issues/4105
* https://github.com/sebastianbergmann/phpunit/issues/4621#issuecomment-797604984