### PR TITLE
fix: remove iconv conversion

### DIFF
--- a/src/Encoder/Encoder.php
+++ b/src/Encoder/Encoder.php
@@ -529,7 +529,7 @@ final class Encoder
                 break;
 
             case Mode::BYTE():
-                self::append8BitBytes($content, $bits, $encoding);
+                self::append8BitBytes($content, $bits);
                 break;
 
             case Mode::KANJI():
@@ -608,17 +608,9 @@ final class Encoder
 
     /**
      * Appends regular 8-bit bytes to a bit array.
-     *
-     * @throws WriterException if content cannot be encoded to target encoding
      */
-    private static function append8BitBytes(string $content, BitArray $bits, string $encoding) : void
+    private static function append8BitBytes(string $bytes, BitArray $bits) : void
     {
-        $bytes = @iconv('utf-8', $encoding, $content);
-
-        if (false === $bytes) {
-            throw new WriterException('Could not encode content to ' . $encoding);
-        }
-
         $length = strlen($bytes);
 
         for ($i = 0; $i < $length; $i++) {


### PR DESCRIPTION
$encoding is hard-code to `ISO-8859-1`

converting utf-8 to `ISO-8859-1` throws a warning.
https://3v4l.org/veXqX

on newer systems even a exception:

```
PHP Fatal error:  Uncaught BaconQrCode\Exception\WriterException: Could not encode content to ISO-8859-1 in /workspace/BaconQrCode/src/Encoder/Encoder.php:619
Stack trace:
#0 /workspace/BaconQrCode/src/Encoder/Encoder.php(532): BaconQrCode\Encoder\Encoder::append8BitBytes()
#1 /workspace/BaconQrCode/src/Encoder/Encoder.php(82): BaconQrCode\Encoder\Encoder::appendBytes()
#2 /workspace/BaconQrCode/src/Writer.php(46): BaconQrCode\Encoder\Encoder::encode()
#3 /workspace/BaconQrCode/src/Writer.php(61): BaconQrCode\Writer->writeString()
#4 /workspace/BaconQrCode/test.php(16): BaconQrCode\Writer->writeFile()
```
