### PR TITLE
fix: remove unnecessary imagedestroy call

### DIFF
--- a/src/Renderer/GDLibRenderer.php
+++ b/src/Renderer/GDLibRenderer.php
@@ -197,7 +197,6 @@ final class GDLibRenderer implements RendererInterface
                 );
         }
 
-        imagedestroy($this->image);
         $this->colors = [];
         $this->image = null;
 


### PR DESCRIPTION
`imagedestroy()` has no effect since PHP 8.0.0 and is deprecated in PHP 8.5