### PR TITLE
refactor: remove redundant "& 0xFF" masks from ord() and BitArray

### DIFF
--- a/src/Encoder/Encoder.php
+++ b/src/Encoder/Encoder.php
@@ -457,7 +457,7 @@ final class Encoder
         $toEncode = new SplFixedArray($numDataBytes + $numEcBytesInBlock);
 
         for ($i = 0; $i < $numDataBytes; $i++) {
-            $toEncode[$i] = $dataBytes[$i] & 0xff;
+            $toEncode[$i] = $dataBytes[$i];
         }
 
         $ecBytes = new SplFixedArray($numEcBytesInBlock);


### PR DESCRIPTION
This change removes unnecessary bitmask operations that were carried over from C-style code:

- In C, `& 0xFF` is used to prevent sign-extension when promoting signed chars (`-128..127`) to ints, ensuring values are treated as unsigned bytes (`0..255`).
- In PHP, `ord()` already returns integers in the range `0–255`, so applying `& 0xFF` is redundant.
- Likewise, `BitArray::toBytes()` produces values in the correct range, making the extra mask in `BitArray::generateEcBytes()` unnecessary.

This simplifies the codebase and makes the implementation more idiomatic to PHP.