### PR TITLE
test: remove deprecated MT_RAND_PHP and fix mt_rand() upper bound

### DIFF
--- a/test/Common/BitArrayTest.php
+++ b/test/Common/BitArrayTest.php
@@ -89,7 +89,7 @@ final class BitArrayTest extends TestCase
 
     public function testGetNextSet5() : void
     {
-        mt_srand(0xdeadbeef, MT_RAND_PHP);
+        mt_srand(0xdeadbeef);
 
         for ($i = 0; $i < 10; ++$i) {
             $array = new BitArray(mt_rand(1, 100));

--- a/test/Common/ReedSolomonCodecTest.php
+++ b/test/Common/ReedSolomonCodecTest.php
@@ -26,7 +26,7 @@ class ReedSolomonCodecTest extends TestCase
     #[DataProvider('tabs')]
     public function testCodec(int $symbolSize, int $generatorPoly, int $firstRoot, int $primitive, int $numRoots) : void
     {
-        mt_srand(0xdeadbeef, MT_RAND_PHP);
+        mt_srand(0xdeadbeef);
 
         $blockSize = (1 << $symbolSize) - 1;
         $dataSize  = $blockSize - $numRoots;
@@ -60,7 +60,7 @@ class ReedSolomonCodecTest extends TestCase
                 $errorValue = mt_rand(1, $blockSize);
 
                 do {
-                    $errorLocation = mt_rand(0, $blockSize);
+                    $errorLocation = mt_rand(0, $blockSize - 1);
                 } while (0 !== $errorLocations[$errorLocation]);
 
                 $errorLocations[$errorLocation] = 1;


### PR DESCRIPTION
Fixes #176.

The test previously seeded error locations with:

```php
do {
    $errorLocation = mt_rand(0, $blockSize);
} while (0 !== $errorLocations[$errorLocation]);
```

This allowed `$errorLocation` to equal `$blockSize`, which is out of range for an array of length `$blockSize` (valid indices are `0 … $blockSize - 1`).

* With **MT_RAND_PHP**, the upper bound was not hit in practice.
* With **MT_RAND_MT19937**, the upper bound is reached, causing an `OutOfBoundsException`.

**Fix:** Correct the upper bound to `$blockSize - 1`:

```php
do {
    $errorLocation = mt_rand(0, $blockSize - 1);
} while (0 !== $errorLocations[$errorLocation]);
```