### PR TITLE
test: remove leftover useless code in BitArrayTest

### DIFF
--- a/test/Common/BitArrayTest.php
+++ b/test/Common/BitArrayTest.php
@@ -111,10 +111,6 @@ final class BitArrayTest extends TestCase
 
                 $actual = $array->getNextSet($query);
 
-                if ($actual !== $expected) {
-                    $array->getNextSet($query);
-                }
-
                 $this->assertEquals($expected, $actual);
             }
         }


### PR DESCRIPTION
As raised in [this comment](https://github.com/Bacon/BaconQrCode/pull/208#issuecomment-3538715499), the following lines are unnecessary and can safely be deleted:

```php
if ($actual !== $expected) {
    $array->getNextSet($query);
}
```

* These lines do not exist in the [source test](https://github.com/zxing/zxing/blob/5a282c5e0506035f77f36b983cb1200341021c06/core/src/test/java/com/google/zxing/common/BitArrayTestCase.java#L102-L121) logic.
* They serve no purpose and appear to be leftover code.
* Removing them improves test clarity and avoids confusion.