### PR TITLE
fix(encoder): use floor() for explicit truncation in MaskUtil

### DIFF
--- a/src/Encoder/MaskUtil.php
+++ b/src/Encoder/MaskUtil.php
@@ -172,7 +172,7 @@ final class MaskUtil
 
         $numTotalCells = $height * $width;
         $darkRatio = $numDarkCells / $numTotalCells;
-        $fixedPercentVariances = (int) (abs($darkRatio - 0.5) * 20);
+        $fixedPercentVariances = (int) floor(abs($darkRatio - 0.5) * 20);
 
         return $fixedPercentVariances * self::N4;
     }


### PR DESCRIPTION
This PR addresses issue #131.

In PHP 8.1+, implicit float-to-int conversion raises precision loss warnings. The current implementation in `MaskUtil.php`:

```php
$fixedPercentVariances = (int) (abs($darkRatio - 0.5) * 20);
```

produces warnings when the result is a non-integer float (e.g., 19.666...).

The QR code specification requires explicit truncation at this step. This PR replaces the cast-only approach with `floor()` to ensure correct behavior and avoid precision loss warnings:

```php
$fixedPercentVariances = (int) floor(abs($darkRatio - 0.5) * 20);
```

This change makes truncation explicit, aligns with the specification, and removes PHP 8.1+ warnings.