### PR TITLE
build(deps): move Pixelmatch from dependencies to devDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "name": "baconqrcode",
-      "dependencies": {
+      "devDependencies": {
         "pixelmatch": "^7.1.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "baconqrcode",
   "private": true,
-  "dependencies": {
+  "devDependencies": {
     "pixelmatch": "^7.1.0"
   }
 }


### PR DESCRIPTION
### Summary

A small follow-up to #206.

Moves the Node.js dependency **Pixelmatch** from `dependencies` to `devDependencies` in package.json.

### Why

- Pixelmatch is only used in unit tests, not in production code.
- With this change, it still installs on `npm install`, but is skipped when running `npm install --production`.
- Improves self-documentation of the project by making it clear that Pixelmatch is a dev-only dependency.

### Refs

From [this answer](https://stackoverflow.com/questions/18875674/whats-the-difference-between-dependencies-devdependencies-and-peerdependencie/22004559#22004559) on Stack Overflow:

>- [`devDependencies`](https://github.com/npm/npm/blob/2e3776bf5676bc24fec6239a3420f377fe98acde/doc/files/package.json.md#devdependencies) are:
>
>    - also installed on `npm install` on a directory that contains `package.json`, unless you pass the `--production` flag, or if the `NODE_ENV=production` environment variable is set
>    - not installed on `npm install "$package"` on any other directory, unless you give it the `--dev` option.
>    - are not installed transitively.