### PR TITLE
build(deps): fix missing "dev" properties in package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/pixelmatch/-/pixelmatch-7.1.0.tgz",
       "integrity": "sha512-1wrVzJ2STrpmONHKBy228LM1b84msXDUoAzVEl0R8Mz4Ce6EPr+IVtxm8+yvrqLYMHswREkjYFaMxnyGnaY3Ng==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "pngjs": "^7.0.0"
@@ -25,6 +26,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-7.0.0.tgz",
       "integrity": "sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=14.19.0"


### PR DESCRIPTION
Fixes an oversight in follow-up to #216, which moved Pixelmatch from `dependencies` to `devDependencies`.

While running `npm install` again for an unrelated reason, I noticed that the `dev` properties were added to `package-lock.json`. I’m not sure why they were missing when I created #216.