### PR TITLE
refactor(mask): simplify MaskUtil::getDataMaskBit implementation

### DIFF
--- a/src/Encoder/MaskUtil.php
+++ b/src/Encoder/MaskUtil.php
@@ -3,7 +3,6 @@ declare(strict_types = 1);
 
 namespace BaconQrCode\Encoder;
 
-use BaconQrCode\Common\BitUtils;
 use BaconQrCode\Exception\InvalidArgumentException;
 
 /**
@@ -204,7 +203,7 @@ final class MaskUtil
                 break;
 
             case 4:
-                $intermediate = (BitUtils::unsignedRightShift($y, 1) + (int) ($x / 3)) & 0x1;
+                $intermediate = ((int) ($y / 2) + (int) ($x / 3)) & 0x1;
                 break;
 
             case 5:

--- a/src/Encoder/MaskUtil.php
+++ b/src/Encoder/MaskUtil.php
@@ -203,7 +203,7 @@ final class MaskUtil
                 break;
 
             case 4:
-                $intermediate = ((int) ($y / 2) + (int) ($x / 3)) & 0x1;
+                $intermediate = (intdiv($y, 2) + intdiv($x, 3)) & 0x1;
                 break;
 
             case 5:

--- a/src/Encoder/MaskUtil.php
+++ b/src/Encoder/MaskUtil.php
@@ -181,7 +181,7 @@ final class MaskUtil
      */
     public static function getDataMaskBit(int $maskPattern, int $x, int $y) : bool
     {
-        return 0 == match ($maskPattern) {
+        return 0 === match ($maskPattern) {
             0 => ($x + $y) % 2,
             1 => $y % 2,
             2 => $x % 3,

--- a/src/Encoder/MaskUtil.php
+++ b/src/Encoder/MaskUtil.php
@@ -185,44 +185,17 @@ final class MaskUtil
      */
     public static function getDataMaskBit(int $maskPattern, int $x, int $y) : bool
     {
-        switch ($maskPattern) {
-            case 0:
-                $intermediate = ($x + $y) % 2;
-                break;
-
-            case 1:
-                $intermediate = $y % 2;
-                break;
-
-            case 2:
-                $intermediate = $x % 3;
-                break;
-
-            case 3:
-                $intermediate = ($x + $y) % 3;
-                break;
-
-            case 4:
-                $intermediate = (intdiv($y, 2) + intdiv($x, 3)) % 2;
-                break;
-
-            case 5:
-                $intermediate = (($x * $y) % 2) + (($x * $y) % 3);
-                break;
-
-            case 6:
-                $intermediate = ((($x * $y) % 2) + (($x * $y) % 3)) % 2;
-                break;
-
-            case 7:
-                $intermediate = ((($x + $y) % 2) + (($x * $y) % 3)) % 2;
-                break;
-
-            default:
-                throw new InvalidArgumentException('Invalid mask pattern: ' . $maskPattern);
-        }
-
-        return 0 == $intermediate;
+        return 0 == match ($maskPattern) {
+            0 => ($x + $y) % 2,
+            1 => $y % 2,
+            2 => $x % 3,
+            3 => ($x + $y) % 3,
+            4 => (intdiv($y, 2) + intdiv($x, 3)) % 2,
+            5 => (($x * $y) % 2) + (($x * $y) % 3),
+            6 => ((($x * $y) % 2) + (($x * $y) % 3)) % 2,
+            7 => ((($x + $y) % 2) + (($x * $y) % 3)) % 2,
+            default => throw new InvalidArgumentException('Invalid mask pattern: ' . $maskPattern),
+        };
     }
 
     /**

--- a/src/Encoder/MaskUtil.php
+++ b/src/Encoder/MaskUtil.php
@@ -3,8 +3,6 @@ declare(strict_types = 1);
 
 namespace BaconQrCode\Encoder;
 
-use BaconQrCode\Exception\InvalidArgumentException;
-
 /**
  * Mask utility.
  */
@@ -180,8 +178,6 @@ final class MaskUtil
      * Returns the mask bit for "getMaskPattern" at "x" and "y".
      *
      * See 8.8 of JISX0510:2004 for mask pattern conditions.
-     *
-     * @throws InvalidArgumentException if an invalid mask pattern was supplied
      */
     public static function getDataMaskBit(int $maskPattern, int $x, int $y) : bool
     {
@@ -194,7 +190,6 @@ final class MaskUtil
             5 => (($x * $y) % 2) + (($x * $y) % 3),
             6 => ((($x * $y) % 2) + (($x * $y) % 3)) % 2,
             7 => ((($x + $y) % 2) + (($x * $y) % 3)) % 2,
-            default => throw new InvalidArgumentException('Invalid mask pattern: ' . $maskPattern),
         };
     }
 

--- a/src/Encoder/MaskUtil.php
+++ b/src/Encoder/MaskUtil.php
@@ -187,11 +187,11 @@ final class MaskUtil
     {
         switch ($maskPattern) {
             case 0:
-                $intermediate = ($y + $x) & 0x1;
+                $intermediate = ($y + $x) % 2;
                 break;
 
             case 1:
-                $intermediate = $y & 0x1;
+                $intermediate = $y % 2;
                 break;
 
             case 2:
@@ -203,22 +203,22 @@ final class MaskUtil
                 break;
 
             case 4:
-                $intermediate = (intdiv($y, 2) + intdiv($x, 3)) & 0x1;
+                $intermediate = (intdiv($y, 2) + intdiv($x, 3)) % 2;
                 break;
 
             case 5:
                 $temp = $y * $x;
-                $intermediate = ($temp & 0x1) + ($temp % 3);
+                $intermediate = ($temp % 2) + ($temp % 3);
                 break;
 
             case 6:
                 $temp = $y * $x;
-                $intermediate = (($temp & 0x1) + ($temp % 3)) & 0x1;
+                $intermediate = (($temp % 2) + ($temp % 3)) % 2;
                 break;
 
             case 7:
                 $temp = $y * $x;
-                $intermediate = (($temp % 3) + (($y + $x) & 0x1)) & 0x1;
+                $intermediate = (($temp % 3) + (($y + $x) % 2)) % 2;
                 break;
 
             default:

--- a/src/Encoder/MaskUtil.php
+++ b/src/Encoder/MaskUtil.php
@@ -187,7 +187,7 @@ final class MaskUtil
     {
         switch ($maskPattern) {
             case 0:
-                $intermediate = ($y + $x) % 2;
+                $intermediate = ($x + $y) % 2;
                 break;
 
             case 1:
@@ -199,7 +199,7 @@ final class MaskUtil
                 break;
 
             case 3:
-                $intermediate = ($y + $x) % 3;
+                $intermediate = ($x + $y) % 3;
                 break;
 
             case 4:
@@ -207,18 +207,15 @@ final class MaskUtil
                 break;
 
             case 5:
-                $temp = $y * $x;
-                $intermediate = ($temp % 2) + ($temp % 3);
+                $intermediate = (($x * $y) % 2) + (($x * $y) % 3);
                 break;
 
             case 6:
-                $temp = $y * $x;
-                $intermediate = (($temp % 2) + ($temp % 3)) % 2;
+                $intermediate = ((($x * $y) % 2) + (($x * $y) % 3)) % 2;
                 break;
 
             case 7:
-                $temp = $y * $x;
-                $intermediate = (($temp % 3) + (($y + $x) % 2)) % 2;
+                $intermediate = ((($x + $y) % 2) + (($x * $y) % 3)) % 2;
                 break;
 
             default:


### PR DESCRIPTION
Several simplifications in the `MaskUtil::getDataMaskBit` implementation, the most significant ones being:
* replacing `BitUtils::unsignedRightShift` with straightforward integer division
* using a PHP `match` expression
