### PR TITLE
feat!: remove deprecated DEFAULT_BYTE_MODE_ECODING constant

### DIFF
--- a/src/Encoder/Encoder.php
+++ b/src/Encoder/Encoder.php
@@ -22,9 +22,6 @@ final class Encoder
      */
     public const DEFAULT_BYTE_MODE_ENCODING = 'ISO-8859-1';
 
-    /** @deprecated use DEFAULT_BYTE_MODE_ENCODING */
-    public const DEFAULT_BYTE_MODE_ECODING = self::DEFAULT_BYTE_MODE_ENCODING;
-
     /**
      * Allowed characters for the Alphanumeric Mode.
      */


### PR DESCRIPTION
BREAKING CHANGE: The deprecated constant Encoder::DEFAULT_BYTE_MODE_ECODING (typo) has been removed. Use Encoder::DEFAULT_BYTE_MODE_ENCODING instead.