### PR TITLE
feat(imagick): add antialias option to ImagickImageBackEnd (#209)

### DIFF
--- a/src/Renderer/Image/ImagickImageBackEnd.php
+++ b/src/Renderer/Image/ImagickImageBackEnd.php
@@ -40,7 +40,9 @@ final class ImagickImageBackEnd implements ImageBackEndInterface
 
     private ?int $matrixIndex;
 
-    public function __construct(string $imageFormat = 'png', int $compressionQuality = 100)
+    private bool $antialias;
+
+    public function __construct(string $imageFormat = 'png', int $compressionQuality = 100, bool $antialias = true)
     {
         if (! class_exists(Imagick::class)) {
             throw new RuntimeException('You need to install the imagick extension to use this back end');
@@ -48,6 +50,7 @@ final class ImagickImageBackEnd implements ImageBackEndInterface
 
         $this->imageFormat = $imageFormat;
         $this->compressionQuality = $compressionQuality;
+        $this->antialias = $antialias;
     }
 
     public function new(int $size, ColorInterface $backgroundColor) : void
@@ -57,6 +60,12 @@ final class ImagickImageBackEnd implements ImageBackEndInterface
         $this->image->setImageFormat($this->imageFormat);
         $this->image->setCompressionQuality($this->compressionQuality);
         $this->draw = new ImagickDraw();
+
+        if (! $this->antialias) {
+            $this->image->setAntiAlias(false);
+            $this->draw->setStrokeAntialias(false);
+        }
+
         $this->gradientCount = 0;
         $this->matrices = [new TransformationMatrix()];
         $this->matrixIndex = 0;


### PR DESCRIPTION
Add a $antialias constructor parameter (default true) to allow disabling antialiasing for sharper images, smaller file sizes, and better nearest-neighbor scalability.

Closes #209