### PR TITLE
build(deps): add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,13 +4,31 @@ updates:
     directory: "/"
     schedule:
       interval: monthly
+    groups:
+      composer-minor-patch:
+        update-types:
+          - minor
+          - patch
+      composer-major:
+        update-types:
+          - major
 
   - package-ecosystem: npm
     directory: "/"
     schedule:
       interval: monthly
+    groups:
+      npm-minor-patch:
+        update-types:
+          - minor
+          - patch
+      npm-major:
+        update-types:
+          - major
 
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
       interval: monthly
+    groups:
+      actions-all: {}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: composer
+    directory: "/"
+    schedule:
+      interval: monthly
+
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: monthly
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: monthly


### PR DESCRIPTION
Adds automated dependency update tracking via [Dependabot](https://docs.github.com/en/code-security/reference/supply-chain-security) ([quickstart guide](https://docs.github.com/en/code-security/tutorials/secure-your-dependencies/dependabot-quickstart-guide)).

### What
Adds `.github/dependabot.yml` with monthly update checks for:
- Composer (phpunit, spatie packages, etc.)
- npm (pixelmatch)
- GitHub Actions

### Why
Dependency updates have been handled manually so far.

For instance, running `npm install` recently bumped pixelmatch from 7.1.0 to 7.2.0 locally, with no automated mechanism to catch and PR that update.

The same applies to GitHub Actions — without automated updates, action versions tend to go stale silently.

### Notes
- Monthly interval chosen given the low dependency count and low churn.
- Dependabot will open one PR per outdated dependency when it triggers. If PR noise becomes an issue, [Renovate](https://docs.renovatebot.com/) with grouping would be a good alternative.

  **Edit:** I later noticed that Dependabot supports grouped updates and added it to the config, so PR noise is no longer a concern — each scheduled run produces at most 2 PRs per ecosystem (one for minor+patch, one for major), and just 1 for GitHub Actions (all updates grouped together).